### PR TITLE
Return sierra contract class  in `RpcStateReader:: get_compiled_contract_class`

### DIFF
--- a/rpc-state-reader/src/blockifier_state_reader.rs
+++ b/rpc-state-reader/src/blockifier_state_reader.rs
@@ -98,9 +98,7 @@ impl StateReader for RpcStateReader {
                     sierra_program_debug_info: None,
                     abi: None,
                 };
-                let casm_cc =
-                    CasmContractClass::from_contract_class(sierra_cc, false, usize::MAX).unwrap();
-                ContractClass::V1(casm_cc.try_into().unwrap())
+                ContractClass::V1Sierra(sierra_cc.try_into().unwrap())
             }
             None => {
                 return Err(StateError::UndeclaredClassHash(


### PR DESCRIPTION
Sierra contract classes are needed to run contract entrypoints using cairo-native. This PR changes the method `get_compiled_contract_class` to return sierra contract classes instead of compiling them to casm contract classes