### PR TITLE
Bump blockifier version to include latest bugfix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.7.0-dev.1"
-source = "git+https://github.com/NethermindEth/blockifier?rev=3844200855dab89ea24f80588c21edb065401123#3844200855dab89ea24f80588c21edb065401123"
+source = "git+https://github.com/NethermindEth/blockifier?rev=3b16c2a3601b9a594c94c325d3c64552b2061a95#3b16c2a3601b9a594c94c325d3c64552b2061a95"
 dependencies = [
  "anyhow",
  "ark-ec",

--- a/rpc-state-reader/Cargo.toml
+++ b/rpc-state-reader/Cargo.toml
@@ -20,7 +20,7 @@ flate2 = "1.0.25"
 serde_with = "3.0.0"
 dotenv = "0.15.0"
 cairo-vm = "0.9.2"
-blockifier = { git = "https://github.com/NethermindEth/blockifier", rev = "3844200855dab89ea24f80588c21edb065401123" }
+blockifier = { git = "https://github.com/NethermindEth/blockifier", rev = "3b16c2a3601b9a594c94c325d3c64552b2061a95" }
 
 
 [dev-dependencies]


### PR DESCRIPTION
This fixes failing tx 0x41497e62fb6798ff66e4ad736121c0164cdb74005aa5dab025be3d90ad4ba06