### PR TITLE
fix: Persist cached state

### DIFF
--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -288,7 +288,6 @@ fn show_execution_data(
     block_number: u64,
     silent: Option<bool>,
 ) {
-    let rpc_chain = parse_network(chain);
     if silent.is_none() || !silent.unwrap() {
         println!("Executing transaction with hash: {}", tx_hash);
         println!("Block number: {}", block_number);
@@ -296,20 +295,14 @@ fn show_execution_data(
     }
     let previous_block_number = BlockNumber(block_number - 1);
 
-    let (tx_info, _trace, receipt) = match execute_tx_configurable(
-        state,
-        &tx_hash,
-        rpc_chain,
-        previous_block_number,
-        false,
-        true,
-    ) {
-        Ok(x) => x,
-        Err(error_reason) => {
-            println!("Error: {}", error_reason);
-            return;
-        }
-    };
+    let (tx_info, _trace, receipt) =
+        match execute_tx_configurable(state, &tx_hash, previous_block_number, false, true) {
+            Ok(x) => x,
+            Err(error_reason) => {
+                println!("Error: {}", error_reason);
+                return;
+            }
+        };
     let TransactionExecutionInfo {
         revert_error,
         actual_fee,

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -100,7 +100,7 @@ fn main() {
 
             let mut state = build_cached_state(&chain, block_number);
 
-            let transaction_hashes = get_transaction_hashes(block_number, &chain)
+            let transaction_hashes = get_transaction_hashes(&chain, block_number)
                 .expect("Unable to fetch the transaction hashes.");
 
             for tx_hash in transaction_hashes {
@@ -118,7 +118,7 @@ fn main() {
             for block_number in block_start..=block_end {
                 let mut state = build_cached_state(&chain, block_number);
 
-                let transaction_hashes = get_transaction_hashes(block_number, &chain)
+                let transaction_hashes = get_transaction_hashes(&chain, block_number)
                     .expect("Unable to fetch the transaction hashes.");
 
                 for tx_hash in transaction_hashes {
@@ -324,7 +324,7 @@ fn show_execution_data(
     }
 }
 
-fn get_transaction_hashes(block_number: u64, network: &str) -> Result<Vec<String>, RpcStateError> {
+fn get_transaction_hashes(network: &str, block_number: u64) -> Result<Vec<String>, RpcStateError> {
     let network = parse_network(network);
     let block_value = BlockValue::Number(BlockNumber(block_number));
     let rpc_state = RpcState::new_rpc(network, block_value)?;

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -100,10 +100,7 @@ fn main() {
 
             let mut state = build_cached_state(&chain, block_number);
 
-            let transaction_hashes = state
-                .state
-                .0
-                .get_transaction_hashes()
+            let transaction_hashes = get_transaction_hashes(block_number, &chain)
                 .expect("Unable to fetch the transaction hashes.");
 
             for tx_hash in transaction_hashes {
@@ -121,10 +118,7 @@ fn main() {
             for block_number in block_start..=block_end {
                 let mut state = build_cached_state(&chain, block_number);
 
-                let transaction_hashes = state
-                    .state
-                    .0
-                    .get_transaction_hashes()
+                let transaction_hashes = get_transaction_hashes(block_number, &chain)
                     .expect("Unable to fetch the transaction hashes.");
 
                 for tx_hash in transaction_hashes {
@@ -330,10 +324,9 @@ fn show_execution_data(
     }
 }
 
-fn get_transaction_hashes(
-    block_number: BlockNumber,
-    network: RpcChain,
-) -> Result<Vec<String>, RpcStateError> {
-    let rpc_state = RpcState::new_rpc(network, BlockValue::Number(block_number))?;
+fn get_transaction_hashes(block_number: u64, network: &str) -> Result<Vec<String>, RpcStateError> {
+    let network = parse_network(network);
+    let block_value = BlockValue::Number(BlockNumber(block_number));
+    let rpc_state = RpcState::new_rpc(network, block_value)?;
     rpc_state.get_transaction_hashes()
 }

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -296,14 +296,20 @@ fn show_execution_data(
     }
     let previous_block_number = BlockNumber(block_number - 1);
 
-    let (tx_info, _trace, receipt) =
-        match execute_tx_configurable(&tx_hash, rpc_chain, previous_block_number, false, true) {
-            Ok(x) => x,
-            Err(error_reason) => {
-                println!("Error: {}", error_reason);
-                return;
-            }
-        };
+    let (tx_info, _trace, receipt) = match execute_tx_configurable(
+        state,
+        &tx_hash,
+        rpc_chain,
+        previous_block_number,
+        false,
+        true,
+    ) {
+        Ok(x) => x,
+        Err(error_reason) => {
+            println!("Error: {}", error_reason);
+            return;
+        }
+    };
     let TransactionExecutionInfo {
         revert_error,
         actual_fee,

--- a/rpc-state-reader/src/blockifier_state_reader.rs
+++ b/rpc-state-reader/src/blockifier_state_reader.rs
@@ -375,6 +375,7 @@ pub fn execute_tx_configurable_with_state(
 }
 
 pub fn execute_tx_configurable(
+    state: &mut CachedState<RpcStateReader>,
     tx_hash: &str,
     network: RpcChain,
     block_number: BlockNumber,
@@ -385,8 +386,6 @@ pub fn execute_tx_configurable(
     TransactionTrace,
     RpcTransactionReceipt,
 )> {
-    let rpc_reader = RpcStateReader(RpcState::new_rpc(network, block_number.into()).unwrap());
-    let mut state = CachedState::new(rpc_reader);
     let tx_hash =
         TransactionHash(StarkFelt::try_from(tx_hash.strip_prefix("0x").unwrap()).unwrap());
     let tx = state.state.0.get_transaction(&tx_hash).unwrap();
@@ -412,7 +411,7 @@ pub fn execute_tx_configurable(
         block_info,
         skip_validate,
         skip_nonce_check,
-        &mut state,
+        state,
     )?;
     let trace = state.state.0.get_transaction_trace(&tx_hash).unwrap();
     let receipt = state.state.0.get_transaction_receipt(&tx_hash).unwrap();

--- a/rpc-state-reader/src/blockifier_state_reader.rs
+++ b/rpc-state-reader/src/blockifier_state_reader.rs
@@ -43,7 +43,7 @@ use crate::{
     utils,
 };
 
-pub struct RpcStateReader(RpcState);
+pub struct RpcStateReader(pub RpcState);
 
 impl RpcStateReader {
     pub fn new(state: RpcState) -> Self {

--- a/rpc-state-reader/src/blockifier_state_reader.rs
+++ b/rpc-state-reader/src/blockifier_state_reader.rs
@@ -292,7 +292,6 @@ fn calculate_class_info_for_testing(contract_class: ContractClass) -> ClassInfo 
 pub fn execute_tx_configurable_with_state(
     tx_hash: &TransactionHash,
     tx: SNTransaction,
-    network: RpcChain,
     block_info: BlockInfo,
     skip_validate: bool,
     skip_nonce_check: bool,
@@ -377,7 +376,6 @@ pub fn execute_tx_configurable_with_state(
 pub fn execute_tx_configurable(
     state: &mut CachedState<RpcStateReader>,
     tx_hash: &str,
-    network: RpcChain,
     block_number: BlockNumber,
     skip_validate: bool,
     skip_nonce_check: bool,
@@ -407,7 +405,6 @@ pub fn execute_tx_configurable(
     let sir_exec_info = execute_tx_configurable_with_state(
         &tx_hash,
         tx,
-        network,
         block_info,
         skip_validate,
         skip_nonce_check,


### PR DESCRIPTION
The current implementation executes each transactions in a block individually with the state from the previous block (n-1). This breaks when transaction on the same block depend on themselves.

## Example

1. An account is deployed
2. The account sends an invoke transaction

If you execute 2. without executing 1., then in your internal state the account won't exist yet, so the transaction will fail. The solution is to persist the state changes between executions of transaction on the same block.

## Note

With the changes introduced in this PR some changes must be made to keep consistency, i.e: `execute_tx_configurable_with_state` originally was the only function that received state but now all of them do, so the function probably doesn't make sense anymore. I think this should be addressed in another PR to keep the bug fix minimal.
