### PR TITLE
Add tracing logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,5 @@
 [workspace]
-members = [
-    "rpc-state-reader",
-    "replay",
-]
+members = ["rpc-state-reader", "replay"]
 
 
 # Explicitly set the resolver to the default for edition >= 2021
@@ -13,3 +10,4 @@ resolver = "2"
 thiserror = "1.0.32"
 starknet_api = "=0.12.0-dev.1"
 blockifier = { git = "https://github.com/NethermindEth/blockifier", rev = "3b16c2a3601b9a594c94c325d3c64552b2061a95" }
+tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -34,3 +34,12 @@ You can use the replay crate to execute transactions or blocks via the CLI. For 
 * cargo run block mainnet 648655
 * cargo run block-range 90000 90002 mainnet
 ```
+
+### Logging
+
+This projects uses tracing with env-filter, so logging can be modified by the RUST_LOG environment variable. By default, only info events from the replay crate are shown.
+
+As an example, to show only error messages from the replay crate, run:
+```bash
+RUST_LOG=replay=error cargo run block mainnet 648461
+```

--- a/replay/Cargo.toml
+++ b/replay/Cargo.toml
@@ -8,15 +8,14 @@ benchmark = []
 
 [dependencies]
 # starknet specific crates
-blockifier = {workspace = true}
+blockifier = { workspace = true }
 rpc-state-reader = { path = "../rpc-state-reader" }
 starknet_api = { workspace = true }
 # CLI specific crates
 clap = { version = "4.4.6", features = ["derive"] }
 indicatif = "0.17.7"
 # logs
-tracing = "0.1"
-tracing-subscriber = "0.3.17"
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 # error handling
 anyhow = "1.0"
-

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -86,7 +86,7 @@ fn main() {
             chain,
             block_number,
         } => {
-            let mut state = build_cached_state(&chain, block_number);
+            let mut state = build_cached_state(&chain, block_number - 1);
             show_execution_data(&mut state, tx_hash, &chain, block_number);
         }
         ReplayExecute::Block {

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -334,7 +334,7 @@ fn set_global_subscriber() {
                 .with_default_directive(default_directive)
                 .from_env_lossy()
         })
-        // .pretty()
+        .pretty()
         .with_file(false)
         .with_line_number(false)
         .finish()

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -113,7 +113,7 @@ fn main() {
             for block_number in block_start..=block_end {
                 let _block_span = info_span!("block", number = block_number).entered();
 
-                let mut state = build_cached_state(&chain, block_number);
+                let mut state = build_cached_state(&chain, block_number - 1);
 
                 let transaction_hashes = get_transaction_hashes(&chain, block_number)
                     .expect("Unable to fetch the transaction hashes.");

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -297,14 +297,15 @@ fn show_execution_data(
         Some(_) => "REVERTED",
         None => "SUCCEEDED",
     };
-    let rpc_status = rpc_receipt.execution_status;
-    let status_matches = execution_status == rpc_status;
+    let rpc_execution_status = rpc_receipt.execution_status;
+    let status_matches = execution_status == rpc_execution_status;
 
     if !status_matches {
         error!(
             transaction_hash = tx_hash,
             chain = chain,
             execution_status,
+            rpc_execution_status,
             execution_error_message = execution_info.revert_error,
             "rpc and execution status diverged"
         )
@@ -313,6 +314,7 @@ fn show_execution_data(
             transaction_hash = tx_hash,
             chain = chain,
             execution_status,
+            rpc_execution_status,
             execution_error_message = execution_info.revert_error,
             "execution finished successfully"
         );


### PR DESCRIPTION
Adds tracing logging to the replay binary. The logs have the following structure:
- A block span for all transactions in a given block
- A transaction span for the execution of a single transaction
- An error event is emitted if the status of the RPC and the blockifier execution don't match, or if the transaction fails unexpectedly
- An info event is emitted if the status matches

<img width="1440" alt="image" src="https://github.com/lambdaclass/starknet-replay/assets/60768809/c3e3baa7-6b2c-4058-a0ef-9d007ec82b72">


