### PR TITLE
Adds Makefile and env.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 debug/
 target/
+
+.env
+.envrc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+.PHONY: usage deps build check test clean
+
+UNAME := $(shell uname)
+
+usage:
+	@echo "Usage:"
+	@echo "    deps:       Installs the necesarry dependencies."
+	@echo "    build:      Builds the crate."
+	@echo "    check:      Checks format and lints."
+	@echo "    test:       Runs all tests."
+	@echo "    clean:      Cleans the built artifacts."
+
+build:
+	cargo build --release
+	# cargo build --release --all-features
+
+check:
+	cargo fmt --all -- --check
+	cargo clippy --all-targets -- -D warnings
+	# cargo clippy --all-targets --all-features -- -D warnings
+
+test:
+	cargo test
+	# cargo test --profile ci --all-features
+
+clean:
+	cargo clean
+
+deps:
+ifeq ($(UNAME), Darwin)
+deps: deps-macos
+endif
+deps:
+
+deps-macos: 
+	-brew install llvm@18 --quiet

--- a/README.md
+++ b/README.md
@@ -1,6 +1,43 @@
 # starknet-replay
 Provides a way of reading a real Starknet State, so you can re-execute an existing transaction in any of the Starknet networks in an easy way
 
+## Getting Started
+
+### Prerequisites
+
+- Linux or macOS (aarch64 included) only for now
+- LLVM 18 with MLIR
+- Rust 1.78.0 or later, since cairo-native makes use of the u128 abi change.
+- Git
+
+### Setup
+
+Run the following make target to install dependencies:
+```bash
+make deps
+```
+It will automatically install LLVM 18 with MLIR on macos, if you are using linux you must do it manually. On debian, you can use `apt.llvm.org`, or build it from source.
+
+This project is integrated with Cairo Native, see [Cairo Native Setup](#cairo-native-setup) to set it up correctly
+
+Some environment variable are needed, you can automatically set them by sourcing `env.sh`. If the script doesn't adjust to your specific environment you can `cp` it into `.env` or `.envrc` and modify it.
+```bash
+# Cairo Native
+export MLIR_SYS_180_PREFIX=/path/to/llvm-18
+export LLVM_SYS_180_PREFIX=/path/to/llvm-18
+export TABLEGEN_180_PREFIX=/path/to/llvm-18
+export CAIRO_NATIVE_RUNTIME_LIBRARY=/path/to/cairo_native/target/release/libcairo_native_runtime.a
+# RPC
+export RPC_ENDPOINT_MAINNET=rpc.endpoint.mainnet.com
+export RPC_ENDPOINT_TESTNET=rpc.endpoint.testnet.com
+```
+
+Once you have installed dependencies and set the needed environment variables, you can build the project and run the tests:
+```bash
+make build
+make test
+```
+
 ### Cairo Native Setup
 
 Starknet Replay is currenlty integrated with [Cairo Native](https://github.com/lambdaclass/cairo_native), which makes the execution of sierra programs possible through native machine code. To use it, the following needs to be setup:

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ This project is integrated with Cairo Native, see [Cairo Native Setup](#cairo-na
 Some environment variable are needed, you can automatically set them by sourcing `env.sh`. If the script doesn't adjust to your specific environment you can `cp` it into `.env` or `.envrc` and modify it.
 ```bash
 # Cairo Native
+export LLVM_SYS_181_PREFIX=/path/to/llvm-18
 export MLIR_SYS_180_PREFIX=/path/to/llvm-18
-export LLVM_SYS_180_PREFIX=/path/to/llvm-18
 export TABLEGEN_180_PREFIX=/path/to/llvm-18
 export CAIRO_NATIVE_RUNTIME_LIBRARY=/path/to/cairo_native/target/release/libcairo_native_runtime.a
 # RPC
@@ -44,10 +44,10 @@ Starknet Replay is currenlty integrated with [Cairo Native](https://github.com/l
 
 - On mac with brew, running `make deps` should have installed LLVM 18 with MLIR, otherwise, you must install it manually. On Debian, you can use `apt.llvm.org`, or build it from source.
 
-- The `LLVM_SYS_180_PREFIX`, `MLIR_SYS_180_PREFIX` and `TABLEGEN_180_PREFIX` environment variable needs to point to said installation. In macOS, run:
+- The `LLVM_SYS_181_PREFIX`, `MLIR_SYS_180_PREFIX` and `TABLEGEN_180_PREFIX` environment variable needs to point to said installation. In macOS, run:
   ```
   export LLVM_SYS_180_PREFIX=/opt/homebrew/opt/llvm@18
-  export MLIR_SYS_180_PREFIX=/opt/homebrew/opt/llvm@18
+  export MLIR_SYS_181_PREFIX=/opt/homebrew/opt/llvm@18
   export TABLEGEN_180_PREFIX=/opt/homebrew/opt/llvm@18
   ```
   and you're set.

--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ make test
 
 Starknet Replay is currenlty integrated with [Cairo Native](https://github.com/lambdaclass/cairo_native), which makes the execution of sierra programs possible through native machine code. To use it, the following needs to be setup:
 
-- LLVM `18` needs to be installed and the `MLIR_SYS_180_PREFIX` and `TABLEGEN_180_PREFIX` environment variable needs to point to said installation. In macOS, run
+- On mac with brew, running `make deps` should have installed LLVM 18 with MLIR, otherwise, you must install it manually. On Debian, you can use `apt.llvm.org`, or build it from source.
+
+- The `LLVM_SYS_180_PREFIX`, `MLIR_SYS_180_PREFIX` and `TABLEGEN_180_PREFIX` environment variable needs to point to said installation. In macOS, run:
   ```
-  brew install llvm@18
-  export MLIR_SYS_180_PREFIX=/opt/homebrew/opt/llvm@18
   export LLVM_SYS_180_PREFIX=/opt/homebrew/opt/llvm@18
+  export MLIR_SYS_180_PREFIX=/opt/homebrew/opt/llvm@18
   export TABLEGEN_180_PREFIX=/opt/homebrew/opt/llvm@18
   ```
   and you're set.

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# It sets the LLVM environment variables.
+#
+# You can copy this file to .envrc/.env and adapt it for your environment.
+
+case $(uname) in
+  Darwin)
+    # If installed with brew
+    MLIR_SYS_180_PREFIX="$(brew --prefix llvm@18)"
+    LLVM_SYS_180_PREFIX="$(brew --prefix llvm@18)"
+    TABLEGEN_180_PREFIX="$(brew --prefix llvm@18)"
+
+    export MLIR_SYS_180_PREFIX
+    export LLVM_SYS_180_PREFIX
+    export TABLEGEN_180_PREFIX
+  ;;
+  Linux)
+    # If installed from Debian/Ubuntu repository:
+    MLIR_SYS_180_PREFIX=/usr/lib/llvm-18
+    LLVM_SYS_180_PREFIX=/usr/lib/llvm-18
+    TABLEGEN_180_PREFIX=/usr/lib/llvm-18
+
+    export MLIR_SYS_180_PREFIX
+    export LLVM_SYS_180_PREFIX
+    export TABLEGEN_180_PREFIX
+  ;;
+esac
+
+# export CAIRO_NATIVE_RUNTIME_LIBRARY=
+# export RPC_ENDPOINT_MAINNET=
+# export RPC_ENDPOINT_TESTNET=
+
+echo "loaded LLVM environment variables"
+echo "remember you must manually set:"
+echo "- RPC_ENDPOINT_MAINNET=rpc.endpoint.mainnet.com"
+echo "- RPC_ENDPOINT_TESTNET=rpc.endpoint.testnet.com"
+echo "- CAIRO_NATIVE_RUNTIME_LIBRARY=path/to/cairo_native/target/release/libcairo_native_runtime.a"

--- a/env.sh
+++ b/env.sh
@@ -7,22 +7,22 @@
 case $(uname) in
   Darwin)
     # If installed with brew
+    LLVM_SYS_181_PREFIX="$(brew --prefix llvm@18)"
     MLIR_SYS_180_PREFIX="$(brew --prefix llvm@18)"
-    LLVM_SYS_180_PREFIX="$(brew --prefix llvm@18)"
     TABLEGEN_180_PREFIX="$(brew --prefix llvm@18)"
 
+    export LLVM_SYS_181_PREFIX
     export MLIR_SYS_180_PREFIX
-    export LLVM_SYS_180_PREFIX
     export TABLEGEN_180_PREFIX
   ;;
   Linux)
     # If installed from Debian/Ubuntu repository:
+    LLVM_SYS_181_PREFIX=/usr/lib/llvm-18
     MLIR_SYS_180_PREFIX=/usr/lib/llvm-18
-    LLVM_SYS_180_PREFIX=/usr/lib/llvm-18
     TABLEGEN_180_PREFIX=/usr/lib/llvm-18
 
+    export LLVM_SYS_181_PREFIX
     export MLIR_SYS_180_PREFIX
-    export LLVM_SYS_180_PREFIX
     export TABLEGEN_180_PREFIX
   ;;
 esac


### PR DESCRIPTION
- Adds makefile with common commands
- Adds env.sh script to set up environment variables.
- Updates README.md to document Makefile commands and env.sh

The --all-features flag was deliberately left out of the make rules as the benchmark feature it's currently being worked on in https://github.com/lambdaclass/starknet-replay/pull/13 (and it does not compile in main). Before merging that PR, it must be added to the Makefile.

I left out some Makefile rules to keep it simple, but I can add them if they are desired:
- `make runtime`: Clones cairo native and compiles the runtime library
- `make check-env`: Checks that all needed env variables are set. If I add this then there is probably no need for printing a remainder in `env.sh`