### PR TITLE
Benchmark feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install LLVM
         run: sudo apt-get install llvm-18 llvm-18-dev llvm-18-runtime clang-18 clang-tools-18 lld-18 libpolly-18-dev libmlir-18-dev mlir-18-tools
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
   format:
     name: rustfmt
@@ -164,4 +164,4 @@ jobs:
           make runtime
           echo "CAIRO_NATIVE_RUNTIME_LIBRARY=$(pwd)/libcairo_native_runtime.a" > $GITHUB_ENV
       - name: Test
-        run: cargo test
+        run: cargo test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3363,6 +3363,7 @@ dependencies = [
  "starknet_api",
  "test-case",
  "thiserror",
+ "tracing",
  "ureq",
 ]
 

--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -93,10 +93,13 @@ fn fetch_block_context(
 /// Can also be used to fill up the cache
 pub fn execute_block_range(block_range_data: &mut Vec<BlockCachedData>) {
     for (state, block_context, transactions) in block_range_data {
+        // For each block
+
         // The transactional state is used to execute a transaction while discarding state changes applied to it.
         let mut transactional_state = CachedState::create_transactional(state);
 
         for (transaction_hash, transaction) in transactions {
+            // Execute each transaction
             let result = execute_tx_with_blockifier(
                 &mut transactional_state,
                 block_context.clone(),

--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -1,0 +1,115 @@
+use crate::{build_cached_state, get_transaction_hashes, parse_network};
+use blockifier::{
+    blockifier::block::BlockInfo,
+    context::{BlockContext, ChainInfo},
+    state::cached_state::CachedState,
+    versioned_constants::VersionedConstants,
+};
+use rpc_state_reader::blockifier_state_reader::{execute_tx_with_blockifier, RpcStateReader};
+use starknet_api::{
+    block::BlockNumber,
+    hash::StarkFelt,
+    transaction::{Transaction as SNTransaction, TransactionHash},
+};
+use tracing::{error, info};
+
+pub fn fetch_block_range_data(
+    block_start: BlockNumber,
+    block_end: BlockNumber,
+    chain: &str,
+) -> Vec<(
+    CachedState<RpcStateReader>,
+    BlockContext,
+    Vec<(TransactionHash, SNTransaction)>,
+)> {
+    let mut block_caches = Vec::new();
+    let rpc_chain = parse_network(chain);
+
+    for block_number in block_start.0..=block_end.0 {
+        // For each block
+        let block_number = BlockNumber(block_number);
+
+        // Create a cached state
+        let state = build_cached_state(&chain, block_number.0 - 1);
+
+        // Fetch block context
+        let block_context = {
+            let rpc_block_info = state.state.0.get_block_info().unwrap();
+
+            let gas_price = state.state.0.get_gas_price(block_number.0).unwrap();
+
+            BlockContext::new_unchecked(
+                &BlockInfo {
+                    block_number,
+                    block_timestamp: rpc_block_info.block_timestamp,
+                    sequencer_address: rpc_block_info.sequencer_address,
+                    gas_prices: gas_price,
+                    use_kzg_da: false,
+                },
+                &ChainInfo {
+                    chain_id: rpc_chain.into(),
+                    fee_token_addresses: Default::default(),
+                },
+                &VersionedConstants::latest_constants_with_overrides(u32::MAX, usize::MAX),
+            )
+        };
+
+        // Fetch transactions for the block
+        let transactions = get_transaction_hashes(&chain, block_number.0)
+            .unwrap()
+            .into_iter()
+            .map(|transaction_hash| {
+                let transaction_hash = TransactionHash(
+                    StarkFelt::try_from(transaction_hash.strip_prefix("0x").unwrap()).unwrap(),
+                );
+
+                // Fetch transaction
+                let transaction = state.state.0.get_transaction(&transaction_hash).unwrap();
+
+                (transaction_hash, transaction)
+            })
+            .collect::<Vec<_>>();
+
+        block_caches.push((state, block_context, transactions));
+    }
+
+    block_caches
+}
+
+pub fn execute_block_range(
+    block_range_data: &mut Vec<(
+        CachedState<RpcStateReader>,
+        BlockContext,
+        Vec<(TransactionHash, SNTransaction)>,
+    )>,
+) {
+    for (state, block_context, transactions) in block_range_data {
+        // The transactional state is used to execute a transaction while discarding all writes to it.
+        let mut transactional_state = CachedState::create_transactional(state);
+
+        for (transaction_hash, transaction) in transactions {
+            let result = execute_tx_with_blockifier(
+                &mut transactional_state,
+                block_context.clone(),
+                transaction.to_owned(),
+                transaction_hash.to_owned(),
+            );
+
+            match result {
+                Ok(info) => {
+                    info!(
+                        transaction_hash = transaction_hash.to_string(),
+                        succeeded = info.revert_error.is_none(),
+                        "tx execution status"
+                    )
+                }
+                Err(_) => error!(
+                    transaction_hash = transaction_hash.to_string(),
+                    "tx execution failed"
+                ),
+            }
+
+            break;
+        }
+    }
+}

--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -109,7 +109,7 @@ pub fn execute_block_range(block_range_data: &mut Vec<BlockCachedData<impl State
 
 /// An implementation of StateReader that can be disabled, panicking if atempted to be read from
 ///
-/// Use to ensure that no requests are been made.
+/// Used to ensure that no requests are made after disabling it.
 pub struct OptionalStateReader<S: StateReader>(pub Option<S>);
 
 impl<S: StateReader> OptionalStateReader<S> {

--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -21,11 +21,11 @@ pub type BlockCachedData = (
 
 /// Fetches context data to execute the given block range
 ///
-/// It does not actually execute them, so not all required data will be cached.
-/// To ensure that all rpc data is cached, the block range must be execute
-/// at least once.
+/// It does not actually execute the block range, so not all data required
+/// by blockifier will be cached. To ensure that all rpc data is cached,
+/// the block range must be executed once.
 ///
-/// See `execute_block_range`
+/// See `execute_block_range` to execute the block range
 pub fn fetch_block_range_data(
     block_start: BlockNumber,
     block_end: BlockNumber,
@@ -88,12 +88,12 @@ fn fetch_block_context(
     )
 }
 
-/// Executes the given block range and discards any state changes
+/// Executes the given block range, discarding any state changes applied to it
 ///
-/// Can be used to fill up the cache
+/// Can also be used to fill up the cache
 pub fn execute_block_range(block_range_data: &mut Vec<BlockCachedData>) {
     for (state, block_context, transactions) in block_range_data {
-        // The transactional state is used to execute a transaction while discarding all writes to it.
+        // The transactional state is used to execute a transaction while discarding state changes applied to it.
         let mut transactional_state = CachedState::create_transactional(state);
 
         for (transaction_hash, transaction) in transactions {

--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -117,8 +117,6 @@ pub fn execute_block_range(block_range_data: &mut Vec<BlockCachedData>) {
                     "tx execution failed"
                 ),
             }
-
-            break;
         }
     }
 }

--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -13,8 +13,8 @@ use starknet_api::{
 };
 use tracing::{error, info};
 
-pub type BlockCachedData<T> = (
-    CachedState<T>,
+pub type BlockCachedData = (
+    CachedState<OptionalStateReader<RpcStateReader>>,
     BlockContext,
     Vec<(TransactionHash, SNTransaction)>,
 );
@@ -30,7 +30,7 @@ pub fn fetch_block_range_data(
     block_start: BlockNumber,
     block_end: BlockNumber,
     chain: RpcChain,
-) -> Vec<BlockCachedData<OptionalStateReader<RpcStateReader>>> {
+) -> Vec<BlockCachedData> {
     let mut block_caches = Vec::new();
 
     for block_number in block_start.0..=block_end.0 {
@@ -74,7 +74,7 @@ pub fn fetch_block_range_data(
 /// Executes the given block range, discarding any state changes applied to it
 ///
 /// Can also be used to fill up the cache
-pub fn execute_block_range(block_range_data: &mut Vec<BlockCachedData<impl StateReader>>) {
+pub fn execute_block_range(block_range_data: &mut Vec<BlockCachedData>) {
     for (state, block_context, transactions) in block_range_data {
         // For each block
 

--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -1,4 +1,4 @@
-use crate::{build_cached_state, get_transaction_hashes, parse_network};
+use crate::{build_cached_state, get_transaction_hashes};
 use blockifier::{
     blockifier::block::BlockInfo,
     context::{BlockContext, ChainInfo},
@@ -13,17 +13,25 @@ use starknet_api::{
 };
 use tracing::{error, info};
 
+pub type BlockCachedData = (
+    CachedState<RpcStateReader>,
+    BlockContext,
+    Vec<(TransactionHash, SNTransaction)>,
+);
+
+/// Fetches context data to execute the given block range
+///
+/// It does not actually execute them, so not all required data will be cached.
+/// To ensure that all rpc data is cached, the block range must be execute
+/// at least once.
+///
+/// See `execute_block_range`
 pub fn fetch_block_range_data(
     block_start: BlockNumber,
     block_end: BlockNumber,
     chain: &str,
-) -> Vec<(
-    CachedState<RpcStateReader>,
-    BlockContext,
-    Vec<(TransactionHash, SNTransaction)>,
-)> {
+) -> Vec<BlockCachedData> {
     let mut block_caches = Vec::new();
-    let rpc_chain = parse_network(chain);
 
     for block_number in block_start.0..=block_end.0 {
         // For each block
@@ -33,26 +41,7 @@ pub fn fetch_block_range_data(
         let state = build_cached_state(&chain, block_number.0 - 1);
 
         // Fetch block context
-        let block_context = {
-            let rpc_block_info = state.state.0.get_block_info().unwrap();
-
-            let gas_price = state.state.0.get_gas_price(block_number.0).unwrap();
-
-            BlockContext::new_unchecked(
-                &BlockInfo {
-                    block_number,
-                    block_timestamp: rpc_block_info.block_timestamp,
-                    sequencer_address: rpc_block_info.sequencer_address,
-                    gas_prices: gas_price,
-                    use_kzg_da: false,
-                },
-                &ChainInfo {
-                    chain_id: rpc_chain.into(),
-                    fee_token_addresses: Default::default(),
-                },
-                &VersionedConstants::latest_constants_with_overrides(u32::MAX, usize::MAX),
-            )
-        };
+        let block_context = fetch_block_context(&state, block_number);
 
         // Fetch transactions for the block
         let transactions = get_transaction_hashes(&chain, block_number.0)
@@ -76,13 +65,33 @@ pub fn fetch_block_range_data(
     block_caches
 }
 
-pub fn execute_block_range(
-    block_range_data: &mut Vec<(
-        CachedState<RpcStateReader>,
-        BlockContext,
-        Vec<(TransactionHash, SNTransaction)>,
-    )>,
-) {
+fn fetch_block_context(
+    state: &CachedState<RpcStateReader>,
+    block_number: BlockNumber,
+) -> BlockContext {
+    let rpc_block_info = state.state.0.get_block_info().unwrap();
+    let gas_price = state.state.0.get_gas_price(block_number.0).unwrap();
+
+    BlockContext::new_unchecked(
+        &BlockInfo {
+            block_number,
+            block_timestamp: rpc_block_info.block_timestamp,
+            sequencer_address: rpc_block_info.sequencer_address,
+            gas_prices: gas_price,
+            use_kzg_da: false,
+        },
+        &ChainInfo {
+            chain_id: state.state.0.get_chain_name().into(),
+            fee_token_addresses: Default::default(),
+        },
+        &VersionedConstants::latest_constants_with_overrides(u32::MAX, usize::MAX),
+    )
+}
+
+/// Executes the given block range and discards any state changes
+///
+/// Can be used to fill up the cache
+pub fn execute_block_range(block_range_data: &mut Vec<BlockCachedData>) {
     for (state, block_context, transactions) in block_range_data {
         // The transactional state is used to execute a transaction while discarding all writes to it.
         let mut transactional_state = CachedState::create_transactional(state);

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -126,7 +126,7 @@ fn main() {
                     // Internally, this fetches all the needed information and caches it
                     let result = execute_tx_configurable(
                         &mut state,
-                        &transaction_hash,
+                        transaction_hash,
                         BlockNumber(block_number),
                         false,
                         false,
@@ -166,7 +166,7 @@ fn main() {
                         // We use the same state from the previous execution
                         let result = execute_tx_configurable(
                             state,
-                            &transaction_hash,
+                            transaction_hash,
                             BlockNumber(*block_number),
                             false,
                             false,

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use blockifier::state::cached_state::CachedState;
 use clap::{Parser, Subcommand};
 use rpc_state_reader::{
@@ -7,34 +9,13 @@ use rpc_state_reader::{
 };
 
 use rpc_state_reader::blockifier_state_reader::execute_tx_configurable;
-#[cfg(feature = "benchmark")]
-use rpc_state_reader::{
-    execute_tx_configurable_with_state, rpc_state::RpcBlockInfo, RpcStateReader,
-};
 use starknet_api::block::BlockNumber;
-#[cfg(feature = "benchmark")]
-use starknet_api::{
-    hash::StarkFelt,
-    stark_felt,
-    transaction::{Transaction, TransactionHash},
-};
-#[cfg(feature = "benchmark")]
-use starknet_in_rust::{
-    definitions::block_context::GasPrices,
-    state::{
-        cached_state::CachedState, contract_class_cache::PermanentContractClassCache, BlockInfo,
-    },
-    transaction::Address,
-    Felt252,
-};
-#[cfg(feature = "benchmark")]
-use std::ops::Div;
-use std::str::FromStr;
-#[cfg(feature = "benchmark")]
-use std::{collections::HashMap, sync::Arc, time::Instant};
 use tracing::{debug, error, info, info_span};
 use tracing_subscriber::filter::Directive;
 use tracing_subscriber::{util::SubscriberInitExt, EnvFilter};
+
+#[cfg(feature = "benchmark")]
+use std::{ops::Div, time::Instant};
 
 #[derive(Debug, Parser)]
 #[command(about = "Replay is a tool for executing Starknet transactions.", long_about = None)]
@@ -68,7 +49,7 @@ Caches all rpc data before the benchmark runs to provide accurate results"
         block_start: u64,
         block_end: u64,
         chain: String,
-        n_runs: usize,
+        number_of_runs: usize,
     },
 }
 
@@ -124,125 +105,99 @@ fn main() {
             block_start,
             block_end,
             chain,
-            n_runs,
+            number_of_runs,
         } => {
-            println!("Filling up Cache");
-            let network = parse_network(&chain);
-            // Create a single class_cache for all states
-            let class_cache = Arc::new(PermanentContractClassCache::default());
-            // HashMaps to cache tx data & states
-            let mut transactions =
-                HashMap::<BlockNumber, Vec<(TransactionHash, Transaction)>>::new();
-            let mut cached_states = HashMap::<
-                BlockNumber,
-                CachedState<RpcStateReader, PermanentContractClassCache>,
-            >::new();
-            let mut block_timestamps = HashMap::<BlockNumber, u64>::new();
-            let mut sequencer_addresses = HashMap::<BlockNumber, Address>::new();
-            let mut gas_prices = HashMap::<BlockNumber, GasPrices>::new();
+            info!("filling up cache");
+
+            let mut block_caches = Vec::new();
+
             for block_number in block_start..=block_end {
-                // For each block:
-                let block_number = BlockNumber(block_number);
+                // For each block
+
                 // Create a cached state
-                let rpc_reader =
-                    RpcStateReader::new(RpcState::new_rpc(network, block_number.into()).unwrap());
-                let mut state = CachedState::new(Arc::new(rpc_reader), class_cache.clone());
-                // Fetch block timestamps & sequencer address
-                let RpcBlockInfo {
-                    block_timestamp,
-                    sequencer_address,
-                    ..
-                } = state.state_reader.0.get_block_info().unwrap();
-                block_timestamps.insert(block_number, block_timestamp.0);
-                let sequencer_address = Address(Felt252::from_bytes_be_slice(
-                    sequencer_address.0.key().bytes(),
-                ));
-                sequencer_addresses.insert(block_number, sequencer_address.clone());
-                // Fetch gas price
-                let gas_price = state.state_reader.0.get_gas_price(block_number.0).unwrap();
-                gas_prices.insert(block_number, gas_price.clone());
+                let mut state = build_cached_state(&chain, block_number - 1);
 
-                // Fetch txs for the block
-                let transaction_hashes = get_transaction_hashes(block_number, network)
-                    .expect("Unable to fetch the transaction hashes.");
-                let mut txs_in_block = Vec::<(TransactionHash, Transaction)>::new();
-                for tx_hash in transaction_hashes {
-                    // Fetch tx and add it to txs_in_block cache
-                    let tx_hash = TransactionHash(stark_felt!(tx_hash.strip_prefix("0x").unwrap()));
-                    let tx = state.state_reader.0.get_transaction(&tx_hash).unwrap();
-                    txs_in_block.push((tx_hash, tx.clone()));
-                    // First execution to fill up cache values
-                    let _ = execute_tx_configurable_with_state(
-                        &tx_hash,
-                        tx.clone(),
-                        network,
-                        BlockInfo {
-                            block_number: block_number.0,
-                            block_timestamp: block_timestamp.0,
-                            gas_price: gas_price.clone(),
-                            sequencer_address: sequencer_address.clone(),
-                        },
-                        false,
-                        true,
+                // Fetch transactions for the block
+                let transaction_hashes = get_transaction_hashes(&chain, block_number).unwrap();
+
+                for transaction_hash in &transaction_hashes {
+                    // Execute each transaction
+
+                    // Internally, this fetches all the needed information and caches it
+                    let result = execute_tx_configurable(
                         &mut state,
+                        &transaction_hash,
+                        BlockNumber(block_number),
+                        false,
+                        false,
                     );
-                }
-                // Add the txs from the current block to the transactions cache
-                transactions.insert(block_number, txs_in_block);
-                // Clean writes from cached_state
-                state.cache_mut().storage_writes_mut().clear();
-                state.cache_mut().class_hash_writes_mut().clear();
-                state.cache_mut().nonce_writes_mut().clear();
-                // Add the cached state for the current block to the cached_states cache
-                cached_states.insert(block_number, state);
-            }
-            // Benchmark run should make no api requests as all data is cached
 
-            println!(
-                "Executing block range: {} - {} {} times",
-                block_start, block_end, n_runs
-            );
-            let now = Instant::now();
-            for _ in 0..n_runs {
-                for block_number in block_start..=block_end {
-                    let block_number = BlockNumber(block_number);
-                    // Fetch state
-                    let state = cached_states.get_mut(&block_number).unwrap();
-                    // Fetch txs
-                    let block_txs = transactions.get(&block_number).unwrap();
-                    // Fetch timestamp
-                    let block_timestamp = *block_timestamps.get(&block_number).unwrap();
-                    // Fetch sequencer address
-                    let sequencer_address = sequencer_addresses.get(&block_number).unwrap();
-                    // Fetch gas price
-                    let gas_price = gas_prices.get(&block_number).unwrap();
-                    // Run txs
-                    for (tx_hash, tx) in block_txs {
-                        let _ = execute_tx_configurable_with_state(
-                            tx_hash,
-                            tx.clone(),
-                            network,
-                            BlockInfo {
-                                block_number: block_number.0,
-                                block_timestamp,
-                                gas_price: gas_price.clone(),
-                                sequencer_address: sequencer_address.clone(),
-                            },
-                            false,
-                            true,
-                            state,
-                        );
+                    match result {
+                        Ok((info, ..)) => {
+                            info!(
+                                transaction_hash,
+                                succeeded = info.revert_error.is_none(),
+                                "tx execution status"
+                            )
+                        }
+                        Err(_) => error!(transaction_hash, "tx execution failed"),
                     }
                 }
+
+                // todo: clear cache, is not public
+                // state.storage_writes_mut().clear();
+                // state.class_hash_writes_mut().clear();
+                // state.nonce_writes_mut().clear();
+
+                block_caches.push((block_number, state, transaction_hashes));
             }
-            let elapsed_time = now.elapsed();
-            println!(
-                "Ran blocks {} - {} {} times in {} seconds. Approximately {} second(s) per run",
+
+            let before_execution = Instant::now();
+
+            info!("replaying with cached state");
+            // Benchmark run should make no api requests as all data is cached
+            // It shouldn't compile contracts with native either
+
+            for _ in 0..number_of_runs {
+                for (block_number, state, transactions) in &mut block_caches {
+                    for transaction_hash in transactions {
+                        // Execute each transaction
+
+                        // We use the same state from the previous execution
+                        let result = execute_tx_configurable(
+                            state,
+                            &transaction_hash,
+                            BlockNumber(*block_number),
+                            false,
+                            false,
+                        );
+
+                        match result {
+                            Ok((info, ..)) => {
+                                info!(
+                                    transaction_hash,
+                                    succeeded = info.revert_error.is_none(),
+                                    "tx execution status"
+                                )
+                            }
+                            Err(_) => error!(transaction_hash, "tx execution failed"),
+                        }
+                    }
+
+                    // todo: clear cache, is not public
+                    // state.storage_writes_mut().clear();
+                    // state.class_hash_writes_mut().clear();
+                    // state.nonce_writes_mut().clear();
+                }
+            }
+
+            let execution_time = before_execution.elapsed();
+
+            let total_run_time = execution_time.as_secs_f64();
+            let average_run_time = total_run_time.div(number_of_runs as f64);
+            info!(
                 block_start,
-                block_end,
-                n_runs,
-                elapsed_time.as_secs_f64(),
-                elapsed_time.as_secs_f64().div(n_runs as f64)
+                block_end, number_of_runs, total_run_time, average_run_time, "benchmark finished",
             );
         }
     }

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -14,17 +14,13 @@ use tracing::{debug, error, info, info_span};
 use tracing_subscriber::filter::Directive;
 use tracing_subscriber::{util::SubscriberInitExt, EnvFilter};
 
+use crate::benchmark::{execute_block_range, fetch_block_range_data};
+
 #[cfg(feature = "benchmark")]
-use {
-    blockifier::{
-        blockifier::block::BlockInfo,
-        context::{BlockContext, ChainInfo},
-        versioned_constants::VersionedConstants,
-    },
-    rpc_state_reader::blockifier_state_reader::execute_tx_with_blockifier,
-    starknet_api::{hash::StarkFelt, transaction::TransactionHash},
-    std::{ops::Div, time::Instant},
-};
+use std::{ops::Div, time::Instant};
+
+#[cfg(feature = "benchmark")]
+mod benchmark;
 
 #[derive(Debug, Parser)]
 #[command(about = "Replay is a tool for executing Starknet transactions.", long_about = None)]
@@ -116,132 +112,37 @@ fn main() {
             chain,
             number_of_runs,
         } => {
-            info!("filling up cache");
+            let block_start = BlockNumber(block_start);
+            let block_end = BlockNumber(block_end);
 
-            let chain_id = parse_network(&chain);
+            info!("fetching block range data");
+            let mut block_range_data = fetch_block_range_data(block_start, block_end, &chain);
 
-            let mut block_caches = Vec::new();
+            info!("filling up execution cache");
+            execute_block_range(&mut block_range_data);
 
-            for block_number in block_start..=block_end {
-                // For each block
-                let block_number = BlockNumber(block_number);
+            {
+                let before_execution = Instant::now();
 
-                // Create a cached state
-                let mut state = build_cached_state(&chain, block_number.0 - 1);
+                info!("replaying with cached state");
+                // Benchmark run should make no api requests as all data is cached
 
-                // Fetch block context
-                let block_context = {
-                    let rpc_block_info = state.state.0.get_block_info().unwrap();
-
-                    let gas_price = state.state.0.get_gas_price(block_number.0).unwrap();
-
-                    BlockContext::new_unchecked(
-                        &BlockInfo {
-                            block_number,
-                            block_timestamp: rpc_block_info.block_timestamp,
-                            sequencer_address: rpc_block_info.sequencer_address,
-                            gas_prices: gas_price,
-                            use_kzg_da: false,
-                        },
-                        &ChainInfo {
-                            chain_id: chain_id.into(),
-                            fee_token_addresses: Default::default(),
-                        },
-                        &VersionedConstants::latest_constants_with_overrides(u32::MAX, usize::MAX),
-                    )
-                };
-
-                // Fetch transactions for the block
-                let transactions = get_transaction_hashes(&chain, block_number.0)
-                    .unwrap()
-                    .into_iter()
-                    .map(|transaction_hash| {
-                        let transaction_hash = TransactionHash(
-                            StarkFelt::try_from(transaction_hash.strip_prefix("0x").unwrap())
-                                .unwrap(),
-                        );
-
-                        // Fetch transaction
-                        let transaction = state.state.0.get_transaction(&transaction_hash).unwrap();
-
-                        (transaction_hash, transaction)
-                    })
-                    .collect::<Vec<_>>();
-
-                // The transactional state is used to execute a transaction while discarding all writes to it.
-                let mut transactional_state = CachedState::create_transactional(&mut state);
-
-                for (transaction_hash, transaction) in &transactions {
-                    // Execute each transaction
-                    // Internally, this fetches all the needed information and caches it
-                    let result = execute_tx_with_blockifier(
-                        &mut transactional_state,
-                        block_context.clone(),
-                        transaction.to_owned(),
-                        transaction_hash.to_owned(),
-                    );
-
-                    match result {
-                        Ok(info) => {
-                            info!(
-                                transaction_hash = transaction_hash.to_string(),
-                                succeeded = info.revert_error.is_none(),
-                                "tx execution status"
-                            )
-                        }
-                        Err(_) => error!(
-                            transaction_hash = transaction_hash.to_string(),
-                            "tx execution failed"
-                        ),
-                    }
+                for _ in 0..number_of_runs {
+                    execute_block_range(&mut block_range_data);
                 }
 
-                block_caches.push((state, block_context, transactions));
+                let execution_time = before_execution.elapsed();
+                let total_run_time = execution_time.as_secs_f64();
+                let average_run_time = total_run_time.div(number_of_runs as f64);
+                info!(
+                    block_start = block_start.0,
+                    block_end = block_end.0,
+                    number_of_runs,
+                    total_run_time,
+                    average_run_time,
+                    "benchmark finished",
+                );
             }
-
-            let before_execution = Instant::now();
-
-            info!("replaying with cached state");
-
-            // Benchmark run should make no api requests as all data is cached
-
-            for _ in 0..number_of_runs {
-                for (state, block_context, transactions) in &mut block_caches {
-                    // The transactional state is used to execute a transaction while discarding all writes to it.
-                    let mut transactional_state = CachedState::create_transactional(state);
-
-                    for (transaction_hash, transaction) in transactions {
-                        let result = execute_tx_with_blockifier(
-                            &mut transactional_state,
-                            block_context.clone(),
-                            transaction.to_owned(),
-                            transaction_hash.to_owned(),
-                        );
-
-                        match result {
-                            Ok(info) => {
-                                info!(
-                                    transaction_hash = transaction_hash.to_string(),
-                                    succeeded = info.revert_error.is_none(),
-                                    "tx execution status"
-                                )
-                            }
-                            Err(_) => error!(
-                                transaction_hash = transaction_hash.to_string(),
-                                "tx execution failed"
-                            ),
-                        }
-                    }
-                }
-            }
-
-            let execution_time = before_execution.elapsed();
-            let total_run_time = execution_time.as_secs_f64();
-            let average_run_time = total_run_time.div(number_of_runs as f64);
-            info!(
-                block_start,
-                block_end, number_of_runs, total_run_time, average_run_time, "benchmark finished",
-            );
         }
     }
 }

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -118,16 +118,15 @@ fn main() {
             info!("fetching block range data");
             let mut block_range_data = fetch_block_range_data(block_start, block_end, &chain);
 
+            // We must execute the block range once first to ensure that all data required by blockifier is chached
             info!("filling up execution cache");
-
-            // We must execute the block range once first to ensure that all required data is cached
             execute_block_range(&mut block_range_data);
 
             {
                 let before_execution = Instant::now();
 
-                info!("replaying with cached state");
                 // Benchmark run should make no api requests as all data is cached
+                info!("replaying with cached state");
 
                 for _ in 0..number_of_runs {
                     execute_block_range(&mut block_range_data);

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -119,6 +119,8 @@ fn main() {
             let mut block_range_data = fetch_block_range_data(block_start, block_end, &chain);
 
             info!("filling up execution cache");
+
+            // We must execute the block range once first to ensure that all required data is cached
             execute_block_range(&mut block_range_data);
 
             {

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -14,10 +14,11 @@ use tracing::{debug, error, info, info_span};
 use tracing_subscriber::filter::Directive;
 use tracing_subscriber::{util::SubscriberInitExt, EnvFilter};
 
-use crate::benchmark::{execute_block_range, fetch_block_range_data};
-
 #[cfg(feature = "benchmark")]
-use std::{ops::Div, time::Instant};
+use {
+    crate::benchmark::{execute_block_range, fetch_block_range_data},
+    std::{ops::Div, time::Instant},
+};
 
 #[cfg(feature = "benchmark")]
 mod benchmark;

--- a/rpc-state-reader/Cargo.toml
+++ b/rpc-state-reader/Cargo.toml
@@ -20,6 +20,7 @@ flate2 = "1.0.25"
 dotenv = "0.15.0"
 cairo-vm = "0.9.2"
 blockifier = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions_sorted = "1.2.3"

--- a/rpc-state-reader/src/blockifier_state_reader.rs
+++ b/rpc-state-reader/src/blockifier_state_reader.rs
@@ -406,8 +406,11 @@ pub fn execute_tx_configurable(
 
 /// Executes a transaction with blockifier
 ///
-/// Unlike execute_transaction_configurable, it does not depend on our state reader
+/// Unlike execute_tx_configurable, it does not depend on our state reader
 /// and can be used with any cached state.
+///
+/// It does not make any query to the state, besides of the ones blockifier
+/// internally makes.
 pub fn execute_tx_with_blockifier(
     state: &mut CachedState<impl StateReader>,
     context: BlockContext,

--- a/rpc-state-reader/src/blockifier_state_reader.rs
+++ b/rpc-state-reader/src/blockifier_state_reader.rs
@@ -376,7 +376,7 @@ pub fn execute_tx_configurable(
     let tx_hash =
         TransactionHash(StarkFelt::try_from(tx_hash.strip_prefix("0x").unwrap()).unwrap());
     let tx = state.state.0.get_transaction(&tx_hash).unwrap();
-    let block_context = fetch_block_context(state, block_number);
+    let block_context = fetch_block_context(&state.state.0, block_number);
     let blockifier_exec_info = execute_tx_with_blockifier(state, block_context, tx, tx_hash)?;
 
     let trace = state.state.0.get_transaction_trace(&tx_hash).unwrap();
@@ -446,12 +446,9 @@ pub fn execute_tx_with_blockifier(
     account_transaction.execute(state, &context, false, true)
 }
 
-pub fn fetch_block_context(
-    state: &CachedState<RpcStateReader>,
-    block_number: BlockNumber,
-) -> BlockContext {
-    let rpc_block_info = state.state.0.get_block_info().unwrap();
-    let gas_price = state.state.0.get_gas_price(block_number.0).unwrap();
+pub fn fetch_block_context(state: &RpcState, block_number: BlockNumber) -> BlockContext {
+    let rpc_block_info = state.get_block_info().unwrap();
+    let gas_price = state.get_gas_price(block_number.0).unwrap();
 
     BlockContext::new_unchecked(
         &BlockInfo {
@@ -462,7 +459,7 @@ pub fn fetch_block_context(
             use_kzg_da: false,
         },
         &ChainInfo {
-            chain_id: state.state.0.get_chain_name(),
+            chain_id: state.get_chain_name(),
             fee_token_addresses: Default::default(),
         },
         &VersionedConstants::latest_constants_with_overrides(u32::MAX, usize::MAX),

--- a/rpc-state-reader/src/rpc_state.rs
+++ b/rpc-state-reader/src/rpc_state.rs
@@ -20,6 +20,7 @@ use starknet_api::{
     transaction::{Transaction as SNTransaction, TransactionHash},
 };
 use std::{collections::HashMap, env, fmt::Display, num::NonZeroU128};
+use tracing::debug;
 
 use crate::{rpc_state_errors::RpcStateError, utils};
 
@@ -351,6 +352,8 @@ impl RpcState {
         method: &str,
         params: &serde_json::Value,
     ) -> Result<T, RpcStateError> {
+        debug!(method, "rpc call");
+
         let payload = serde_json::json!({
             "jsonrpc": "2.0",
             "method": method,


### PR DESCRIPTION
Adds `BenchBlockRange` Command to Replay crate under the Benchmark features.

The command is used to measure the performance of Cairo Native without the overhead of rpc requests. Caching native compilation is not yet possible in the current blockifier version

Supersedes #12

## Overview

The bench block range command has roughly three distinct steps:

1. Fetch all block range data, this includes all transactions and block context information needed to execute them
2. Executes the whole block range once, to make sure all internal data required by blockifier is cached
3. Executes (and measures) the whole block range `n` times. This third step won't make any rpc call as all data has already been cached.

The benchmark command ended up being quite lengthy, so I left the high level command implementation in `main.rs` and put the inner details in `benchmark.rs`

## `execute_tx_with_blockifier`

Internally, both `execute_tx_configurable` and `execute_tx_configurable_with_state` depended on our rpc state reader, bypassing the cached state. When executing transaction for benchmarking, I needed it to be indepent of the inner state reader: `CachedState<impl StateReader>`. To solve this I made a new function `execute_tx_with_blockifier`, that does not depend on our rpc state and is just a wrapper around blockifier execution. It receives all contextual information to execute the transaction. 

`execute_tx_configurable_with_state` could be replaced by this new function. I didn't do it in this PR to avoid having to many changes.

## `OptionalStateReader`

To ensure that no requests are made when benchmarking, an `OptionalStateReader` was used instead of our `StateReader`. This reader can be disabled so that it panics if it is attempted to read from when benchmarking

## Benchmark Result in the Server

I benchmarked a single run of block 606173  in `starknet-benchmarks'. It contains 28 transactions.
- total run time: 858.34s

<img width="1417" alt="image" src="https://github.com/lambdaclass/starknet-replay/assets/60768809/c7f232b7-5245-469d-abb9-a60717f3763e">

