### PR TITLE
Add the only_cairo_vm feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.7.0-dev.1"
-source = "git+https://github.com/lambdaclass/blockifier?rev=d458a8d64b6d31da49c447576894ce013af862c2#d458a8d64b6d31da49c447576894ce013af862c2"
+source = "git+https://github.com/lambdaclass/blockifier?rev=c675896abd183b268aa87d838388339ae0ca6545#c675896abd183b268aa87d838388339ae0ca6545"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.2.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=905d6959662edfec4829568f995206fcb8bf64d0#905d6959662edfec4829568f995206fcb8bf64d0"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=6526193a85f282c4ff58bd15d31ca77ccfd580ba#6526193a85f282c4ff58bd15d31ca77ccfd580ba"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -1087,7 +1087,7 @@ dependencies = [
 [[package]]
 name = "cairo-native-runtime"
 version = "0.2.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=905d6959662edfec4829568f995206fcb8bf64d0#905d6959662edfec4829568f995206fcb8bf64d0"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=6526193a85f282c4ff58bd15d31ca77ccfd580ba#6526193a85f282c4ff58bd15d31ca77ccfd580ba"
 dependencies = [
  "cairo-lang-runner",
  "cairo-lang-sierra-gas",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.7.0-dev.1"
-source = "git+https://github.com/lambdaclass/blockifier?rev=c675896abd183b268aa87d838388339ae0ca6545#c675896abd183b268aa87d838388339ae0ca6545"
+source = "git+https://github.com/lambdaclass/blockifier?rev=8eab209eabee1359bec1cc0e9d0a34542a8b65a5#8eab209eabee1359bec1cc0e9d0a34542a8b65a5"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.2.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=6526193a85f282c4ff58bd15d31ca77ccfd580ba#6526193a85f282c4ff58bd15d31ca77ccfd580ba"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=72d10b7923cb4f97ae0b1688ea7de1d34297b0b2#72d10b7923cb4f97ae0b1688ea7de1d34297b0b2"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -1087,7 +1087,7 @@ dependencies = [
 [[package]]
 name = "cairo-native-runtime"
 version = "0.2.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=6526193a85f282c4ff58bd15d31ca77ccfd580ba#6526193a85f282c4ff58bd15d31ca77ccfd580ba"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=72d10b7923cb4f97ae0b1688ea7de1d34297b0b2#72d10b7923cb4f97ae0b1688ea7de1d34297b0b2"
 dependencies = [
  "cairo-lang-runner",
  "cairo-lang-sierra-gas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ resolver = "2"
 [workspace.dependencies]
 thiserror = "1.0.32"
 starknet_api = "=0.12.0-dev.1"
-blockifier = { git = "https://github.com/lambdaclass/blockifier", rev = "d458a8d64b6d31da49c447576894ce013af862c2" }
+blockifier = { git = "https://github.com/lambdaclass/blockifier", rev = "c675896abd183b268aa87d838388339ae0ca6545" }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ resolver = "2"
 [workspace.dependencies]
 thiserror = "1.0.32"
 starknet_api = "=0.12.0-dev.1"
-blockifier = { git = "https://github.com/lambdaclass/blockifier", rev = "c675896abd183b268aa87d838388339ae0ca6545" }
+blockifier = { git = "https://github.com/lambdaclass/blockifier", rev = "8eab209eabee1359bec1cc0e9d0a34542a8b65a5" }
 tracing = "0.1"

--- a/replay/Cargo.toml
+++ b/replay/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [features]
 benchmark = []
+only_cairo_vm = ["rpc-state-reader/only_casm"]
 
 [dependencies]
 # starknet specific crates

--- a/replay/Cargo.toml
+++ b/replay/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [features]
 benchmark = []
+# The only_cairo_vm feature is designed to avoid executing transitions with cairo_native and instead use cairo_vm exclusively
 only_cairo_vm = ["rpc-state-reader/only_casm"]
 
 [dependencies]

--- a/rpc-state-reader/Cargo.toml
+++ b/rpc-state-reader/Cargo.toml
@@ -3,6 +3,11 @@ name = "rpc-state-reader"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# The only_casm features, compiles all the sierra fetched contracts to casm.
+# We use this feature in case we want to avoid using cairo_native in the Replay crate
+only_casm = []
+
 [dependencies]
 ureq = { version = "2.7.1", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/rpc-state-reader/Cargo.toml
+++ b/rpc-state-reader/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-# The only_casm features, compiles all the sierra fetched contracts to casm.
-# We use this feature in case we want to avoid using cairo_native in the Replay crate
+# The only_casm feature compiles all the Sierra fetched contracts to CASM.
+# We use this feature to avoid using cairo_native in the Replay crate.
 only_casm = []
 
 [dependencies]

--- a/rpc-state-reader/src/blockifier_state_reader.rs
+++ b/rpc-state-reader/src/blockifier_state_reader.rs
@@ -89,7 +89,14 @@ impl StateReader for RpcStateReader {
                     sierra_program_debug_info: None,
                     abi: None,
                 };
-                ContractClass::V1Sierra(sierra_cc.try_into().unwrap())
+
+                if cfg!(feature = "only_casm") {
+                    let casm_cc =
+                    cairo_lang_starknet_classes::casm_contract_class::CasmContractClass::from_contract_class(sierra_cc, false, usize::MAX).unwrap();
+                    ContractClass::V1(casm_cc.try_into().unwrap())
+                } else {
+                    ContractClass::V1Sierra(sierra_cc.try_into().unwrap())
+                }
             }
             None => {
                 return Err(StateError::UndeclaredClassHash(


### PR DESCRIPTION
Add the only_cairo_vm feature to the replay crate. This feature is designed to avoid executing transitions with cairo_native and instead use cairo_vm exclusively. It is useful for testing, comparing results, and benchmarking.

To support this, we also introduce the only_casm feature in the rpc_state_reader crate.

