### PR TITLE
Add all-features to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ check:
 	cargo clippy --all-targets --all-features -- -D warnings
 
 test:
-	cargo test --all-features
+	cargo test
 
 clean:
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ usage:
 	@echo "    clean:      Cleans the built artifacts."
 
 build:
-	cargo build --release --all-features
+	cargo build --release --features benchmark
 
 check:
 	cargo fmt --all -- --check

--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,14 @@ usage:
 	@echo "    clean:      Cleans the built artifacts."
 
 build:
-	cargo build --release
-	# cargo build --release --all-features
+	cargo build --release --all-features
 
 check:
 	cargo fmt --all -- --check
-	cargo clippy --all-targets -- -D warnings
-	# cargo clippy --all-targets --all-features -- -D warnings
+	cargo clippy --all-targets --all-features -- -D warnings
 
 test:
-	cargo test
-	# cargo test --profile ci --all-features
+	cargo test --all-features
 
 clean:
 	cargo clean


### PR DESCRIPTION
When we added the Makefile, we intentionally left out the all-features flag because the benchmark feature didn't compile. Now the benchmark feature works correctly, so we can add the flag to the makefile.