### PR TITLE
Update blockifier to sequencer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       TABLEGEN_180_PREFIX: /usr/lib/llvm-18/
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.79.0
+      - uses: dtolnay/rust-toolchain@1.80.0
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.79.0
+      - uses: dtolnay/rust-toolchain@1.80.0
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -86,12 +86,12 @@ jobs:
       MLIR_SYS_180_PREFIX: /usr/lib/llvm-18/
       LLVM_SYS_180_PREFIX: /usr/lib/llvm-18/
       TABLEGEN_180_PREFIX: /usr/lib/llvm-18/
-      RUSTUP_TOOLCHAIN: nightly-2024-02-01  # udeps needs nightly
+      RUSTUP_TOOLCHAIN: nightly  # udeps needs nightly
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@1.80.0
         with:
-          toolchain: nightly-2024-02-01
+          toolchain: nightly
           components: rustfmt
 
       - name: Add llvm deb repository
@@ -139,7 +139,7 @@ jobs:
           sudo rm -rf /usr/local/lib/android
           df -h
       - name: Setup rust env
-        uses: dtolnay/rust-toolchain@1.79.0
+        uses: dtolnay/rust-toolchain@1.80.0
       - name: Retreive cached dependecies
         uses: Swatinem/rust-cache@v2
       - name: Add LLVM Debian repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: lambdaclass/cairo_native
-          ref: 66e9b5e053faf3b2a9129de5b15205d1cfe686eb
+          ref: 4355357697e9ab57ab88ae3a4282aac61455619e
           path: cairo_native
       - name: Build Cairo Native Runtime Library
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.0.0"
+source = "git+https://github.com/lambdaclass/sequencer?branch=native2.8.x-arc#219f78f987dfe41fed5965e81902d3b9998f87e1"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2995,6 +2996,7 @@ dependencies = [
 [[package]]
 name = "papyrus_config"
 version = "0.0.0"
+source = "git+https://github.com/lambdaclass/sequencer?branch=native2.8.x-arc#219f78f987dfe41fed5965e81902d3b9998f87e1"
 dependencies = [
  "clap",
  "itertools 0.10.5",
@@ -4334,6 +4336,7 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.0.0"
+source = "git+https://github.com/lambdaclass/sequencer?branch=native2.8.x-arc#219f78f987dfe41fed5965e81902d3b9998f87e1"
 dependencies = [
  "bitvec",
  "cairo-lang-starknet-classes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,8 +461,7 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.8.0-rc.1"
-source = "git+https://github.com/lambdaclass/blockifier?branch=native2.8.x-adapt#30be79624894e4c6d2277dfd8c010e9f5408a748"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -486,7 +485,7 @@ dependencies = [
  "num-integer",
  "num-rational",
  "num-traits 0.2.19",
- "once_cell",
+ "papyrus_config",
  "paste",
  "phf",
  "serde",
@@ -495,9 +494,11 @@ dependencies = [
  "sha3",
  "starknet-types-core",
  "starknet_api",
- "strum",
- "strum_macros",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
+ "tempfile",
  "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -2306,6 +2307,17 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
@@ -2313,6 +2325,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "if_chain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "ignore"
@@ -2683,6 +2701,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,6 +2990,19 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2",
+]
+
+[[package]]
+name = "papyrus_config"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "itertools 0.10.5",
+ "serde",
+ "serde_json",
+ "strum_macros 0.25.3",
+ "thiserror",
+ "validator",
 ]
 
 [[package]]
@@ -4296,9 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "starknet_api"
-version = "0.13.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a80f50db7439ceb65de759fcbadb1695c82aec82126b2313413632e40d4eec"
+version = "0.0.0"
 dependencies = [
  "bitvec",
  "cairo-lang-starknet-classes",
@@ -4306,15 +4341,14 @@ dependencies = [
  "hex",
  "indexmap 2.4.0",
  "itertools 0.12.1",
- "once_cell",
  "primitive-types",
  "serde",
  "serde_json",
  "sha3",
  "starknet-crypto 0.5.2",
  "starknet-types-core",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "thiserror",
 ]
 
@@ -4362,6 +4396,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4372,6 +4412,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4910,7 +4963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
 ]
 
@@ -4935,6 +4988,45 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "validator"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d6937c33ec6039d8071bcf72933146b5bbe378d645d8fa59bdadabfc2a249"
+dependencies = [
+ "idna 0.2.3",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286b4497f270f59276a89ae0ad109d5f8f18c69b613e3fb22b61201aadb0c4d"
+dependencies = [
+ "if_chain",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_types"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9680608df133af2c1ddd5eaf1ddce91d60d61b6bc51494ef326458365a470a"
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "aquamarine"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21cc1548309245035eb18aa7f0967da6bc65587005170c56e6ef2788a4cf3f4e"
+dependencies = [
+ "include_dir",
+ "itertools 0.10.5",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
+]
+
+[[package]]
 name = "ark-ec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,7 +462,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.8.0-rc.1"
-source = "git+https://github.com/lambdaclass/blockifier?branch=native2.7.x-adapt#6b543142f3ca7f361d2eb67697a65f748b3868e1"
+source = "git+https://github.com/lambdaclass/blockifier?branch=native2.8.x-adapt#30be79624894e4c6d2277dfd8c010e9f5408a748"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -579,9 +593,9 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4425280959f189d8a5ebf1f5363c10663bc9f843a4819253e6be87d183b583e"
+checksum = "ad9e8fe95ee2add1537d00467b98bb8928334633eb01dcba7f33fb64769af259"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -593,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2698e2ca73db964e6d496a648fcbb2ace5559941b5179ab3310c9a0b6872b348"
+checksum = "0db1ae47b4918a894b60160fac42e6fbcb5a8c0023dd6c290ba03a1bcdf5a554"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -610,7 +624,8 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "indoc",
- "salsa",
+ "rayon",
+ "rust-analyzer-salsa",
  "semver",
  "smol_str",
  "thiserror",
@@ -618,18 +633,18 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac7332f2b041ca28b24b0311a0b4a35f426bb52836a2d268a8374ea262e9e6b"
+checksum = "b1c87b905b74516c33fc7e6d61b5243363ce65133054c30bd9531f47e30ca201"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "079a34b560a82b463cd12ae62022d70981e8ab56b6505f9499348ebeaf460de8"
+checksum = "611996d85ec608bfec75d546a5c2ec44f664f4bd2514840a5b369d30a1a8bfdb"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -638,15 +653,15 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "itertools 0.12.1",
- "salsa",
+ "rust-analyzer-salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29625349297ad791942377763f5b04c779ea694f436488dc6ad194720b89487"
+checksum = "d015a0790b1f5de8b22b4b4b60d392c35bed07b7aa9dd22361af2793835cee51"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -656,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb26cd75126db6eaf94d5dffe0ce750d030ac879a88de5a621551969e9b59e3"
+checksum = "54c580e56e5857d51b6bf2ec5ed5fdd33fd3b74dad7e3cb6d7398396174a6c85"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -666,14 +681,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "651012f2956bea884c7a3ab9df21dc76112d7edd3f403b37ca5be62fc3f41b09"
+checksum = "5368e66a742b8532d656171525bfea599490280ceee10bdac93ad60775fc4e59"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
  "path-clean",
- "salsa",
+ "rust-analyzer-salsa",
  "semver",
  "serde",
  "smol_str",
@@ -681,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d09ffb9498368cf4e95d0b28662596331aef1677e4f759ab5e609d27dfcb587"
+checksum = "c1200324728e7f4c4acedceee427d9b3ffce221af57e469a454f007cbc248255"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -694,7 +709,7 @@ dependencies = [
  "diffy",
  "ignore",
  "itertools 0.12.1",
- "salsa",
+ "rust-analyzer-salsa",
  "serde",
  "smol_str",
  "thiserror",
@@ -702,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4ffe6c197c35dec665029fcf695422f02c55b5118b4da1142e182b9fe77f87"
+checksum = "2a7a3069c75e1aca7cf15f20d03baf71f5c86e5be26988f6c25656549aa8b54a"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -720,16 +735,15 @@ dependencies = [
  "log",
  "num-bigint",
  "num-traits 0.2.19",
- "once_cell",
- "salsa",
+ "rust-analyzer-salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f262ad5f1110ff70c93deb81cce024cf160f4a4518762e7deb2047fe73846789"
+checksum = "c13b245ddc740ebfed8b05e1bdb7805a06d267cf89d46486c9609306f92d45ce"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -740,16 +754,16 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint",
  "num-traits 0.2.19",
- "salsa",
+ "rust-analyzer-salsa",
  "smol_str",
  "unescaper",
 ]
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18024b44b5edbc1f378ba85c1a4ff04e880ea465a33251053aec507f08250668"
+checksum = "3b656552d0ab4a69be223e42c4e1c4028e512f506a237d04bbe4ccab9a1e13c5"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -760,15 +774,15 @@ dependencies = [
  "indent",
  "indoc",
  "itertools 0.12.1",
- "salsa",
+ "rust-analyzer-salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124402d8fad2a033bb36910dd7d0651f3100845c63dce679c58797a8cb0448c2"
+checksum = "05cc6adb49faa42ea825e041dff0496c2e72e4ddaf50734062a62383c0c8adbf"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -777,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f37dba9653eabf4dcb43a5e1436cd6bc093b5ad6f28ff42eaaef12549014213"
+checksum = "ad123ba0e0dd5e1ea80977c0244ff4b0b6d8bf050d42ecb5ff0cf7f885e871f9"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -791,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18df87ee986ca0e02e2ea63483875b791602809873c908bbf7b3d592e3833a3a"
+checksum = "be1227ee50d291f4221f2befab3c107720bd9eb1a4da3783f61481a05ac055e2"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
@@ -822,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1612476b548e9ab8ae89ee38a73d9875339f62f2f59d9ce8a719bc1761c54c3"
+checksum = "0d528c79e4ff3e1364569c07e22660ddf60c0d1989705b8f0feed9949962b28a"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -841,17 +855,16 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint",
  "num-traits 0.2.19",
- "once_cell",
- "salsa",
+ "rust-analyzer-salsa",
  "smol_str",
  "toml",
 ]
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8209be8cf22263bf8a55df334a642b74fe563beecbbbefa55cda39fa4b131a61"
+checksum = "1bdb0c2cc419f45ab7e413322502ca02c2a2c56aeabdd0885e3740f378d8b269"
 dependencies = [
  "anyhow",
  "cairo-lang-utils",
@@ -864,9 +877,8 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits 0.2.19",
- "once_cell",
  "regex",
- "salsa",
+ "rust-analyzer-salsa",
  "serde",
  "serde_json",
  "sha3",
@@ -877,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9d1350366c23e4a9f6e18ea95939f18df52df455f06c0e3d7889f80ce18a94"
+checksum = "7224cd827ccf69e742c90a60278876865a96b545a101248d9472d2e02f9190b3"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -893,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe1ff15052b173537360b7dca5f9b2ccb10392b2a1c11af99add35d42632115"
+checksum = "7e379e3010827fe983e66aa38a0d25fe24cfc11eaf8cadf4dc7bcb31fff031de"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -909,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3802e7b6722fabc9cc0a61c86e7ad53138f6f41880aca80a60f889739fbf55"
+checksum = "d6b353930676c06bb885a16ec3b120109aa15539c49f41b3370a5a6314dc29dc"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -925,8 +937,7 @@ dependencies = [
  "cairo-lang-utils",
  "itertools 0.12.1",
  "num-traits 0.2.19",
- "once_cell",
- "salsa",
+ "rust-analyzer-salsa",
  "serde",
  "serde_json",
  "smol_str",
@@ -934,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355bde3b0a835bac2457af133a9042a7d039c934e678905b843bb6b420884428"
+checksum = "83873751d489aae4674f3d755a4897429a664bdc4b0847283e13889f0b0c2a44"
 dependencies = [
  "assert_matches",
  "cairo-lang-casm",
@@ -955,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddddaacc814e0ffda9f176c913fb2a9cd74fe6594dea789e8281eef10cac201"
+checksum = "5bd84b445715326e44832836732b6bda76a119116b296ac9b6b87e2a4177634a"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -965,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10be5fd5fe78db232b032e25e4be786f8061606be4ab26371c869c5ab267699c"
+checksum = "d8df3086f909d27a49d6706be835725df4e21fb50efe699cd763d1f782a31dea"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -986,7 +997,6 @@ dependencies = [
  "indent",
  "indoc",
  "itertools 0.12.1",
- "once_cell",
  "serde",
  "serde_json",
  "smol_str",
@@ -996,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bf919d0919fce727c6d53ee5cb37459c9db35c258521284523c53f5f907c07"
+checksum = "41bcab650779b3431389dc52f1e643a7c9690a1aa2b072c8f01955503d094007"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -1009,7 +1019,6 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits 0.2.19",
- "once_cell",
  "serde",
  "serde_json",
  "sha3",
@@ -1020,25 +1029,25 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a376f88d815b63505be54a6afa93d75b67cfd65835922ec648cfcbb0a5e4b4"
+checksum = "7e2dc876ec02a197b8d13dbfc0b2cf7a7e31dcfc6446761cbb85f5b42d589cdc"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
  "cairo-lang-utils",
  "num-bigint",
  "num-traits 0.2.19",
- "salsa",
+ "rust-analyzer-salsa",
  "smol_str",
  "unescaper",
 ]
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f276bc28f6302fc63032046a12b60d18498906e65f646acb963244eed97f7c"
+checksum = "a8727fe3f24ec0834ec6656c70a59f85233439f0a09ca53cf5e27fbdb1b40193"
 dependencies = [
  "genco",
  "xshell",
@@ -1046,15 +1055,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-plugin"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4cc569e35642d48ba2c75ba500397887a54fa5ead441e005b59968445851b99"
+checksum = "ad43180395d6e36bb8c43300c0a0175b67962161370857ce0f4ff1ea91ed7094"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
  "cairo-lang-debug",
  "cairo-lang-defs",
- "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
  "cairo-lang-lowering",
  "cairo-lang-semantic",
@@ -1074,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e90b6236439e19077ec913351a17a33c7be199dcafdacd8389c4c5199400d6"
+checksum = "7a7681562268173d74b1c8d2438a1d9ec3218c89a8e39a8be3f10e044fa46ebe"
 dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-utils",
@@ -1087,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a394e545f1500bea093d01be40895d3234faaa24d9585d08a509c514cabd88"
+checksum = "37e6004780c42bf28ce5afd048cc628b3de34aaf24fd2c228ae73217c58999f9"
 dependencies = [
  "hashbrown 0.14.5",
  "indexmap 2.4.0",
@@ -1104,15 +1112,15 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.2.0"
-source = "git+https://github.com/lambdaclass/cairo_native?branch=cairo-lang2.7.0-rc.3#f3d29265b8592745003d90f668f2a0aa5fca02b4"
+source = "git+https://github.com/lambdaclass//cairo_native.git?rev=4355357697e9ab57ab88ae3a4282aac61455619e#4355357697e9ab57ab88ae3a4282aac61455619e"
 dependencies = [
  "anyhow",
+ "aquamarine",
  "bumpalo",
  "cairo-lang-compiler",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
- "cairo-lang-lowering",
  "cairo-lang-runner",
  "cairo-lang-semantic",
  "cairo-lang-sierra",
@@ -1128,7 +1136,6 @@ dependencies = [
  "clap",
  "colored",
  "educe",
- "id-arena",
  "itertools 0.13.0",
  "k256",
  "keccak",
@@ -1154,13 +1161,14 @@ dependencies = [
 [[package]]
 name = "cairo-native-runtime"
 version = "0.2.0"
-source = "git+https://github.com/lambdaclass/cairo_native?branch=cairo-lang2.7.0-rc.3#f3d29265b8592745003d90f668f2a0aa5fca02b4"
+source = "git+https://github.com/lambdaclass//cairo_native.git?rev=4355357697e9ab57ab88ae3a4282aac61455619e#4355357697e9ab57ab88ae3a4282aac61455619e"
 dependencies = [
  "cairo-lang-sierra-gas",
  "lazy_static",
  "libc",
- "starknet-crypto 0.6.2",
- "starknet-curve 0.4.2",
+ "rand",
+ "starknet-crypto 0.7.1",
+ "starknet-curve 0.5.0",
  "starknet-types-core",
 ]
 
@@ -1197,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
 dependencies = [
  "jobserver",
  "libc",
@@ -1569,7 +1577,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.10",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2140,15 +2148,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -2367,6 +2366,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -2978,37 +2996,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.10",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3019,7 +3012,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3252,6 +3245,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3312,12 +3329,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
+name = "rayon"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
- "bitflags 1.3.2",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3510,6 +3538,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-analyzer-salsa"
+version = "0.17.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719825638c59fd26a55412a24561c7c5bcf54364c88b9a7a04ba08a6eafaba8d"
+dependencies = [
+ "indexmap 2.4.0",
+ "lock_api",
+ "oorandom",
+ "parking_lot",
+ "rust-analyzer-salsa-macros",
+ "rustc-hash",
+ "smallvec",
+ "tracing",
+ "triomphe",
+]
+
+[[package]]
+name = "rust-analyzer-salsa-macros"
+version = "0.17.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d96498e9684848c6676c399032ebc37c52da95ecbefa83d71ccc53b9f8a4a8e"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3633,35 +3690,6 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "salsa"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b84d9f96071f3f3be0dc818eae3327625d8ebc95b58da37d6850724f31d3403"
-dependencies = [
- "crossbeam-utils",
- "indexmap 1.9.3",
- "lock_api",
- "log",
- "oorandom",
- "parking_lot 0.11.2",
- "rustc-hash",
- "salsa-macros",
- "smallvec",
-]
-
-[[package]]
-name = "salsa-macros"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3904a4ba0a9d0211816177fd34b04c7095443f8cdacd11175064fe541c8fe2"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "salsa20"
@@ -3995,6 +4023,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "starknet"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4089,7 +4123,7 @@ dependencies = [
  "num-traits 0.2.19",
  "rfc6979",
  "sha2",
- "starknet-crypto-codegen",
+ "starknet-crypto-codegen 0.3.3",
  "starknet-curve 0.3.0",
  "starknet-ff",
  "zeroize",
@@ -4109,9 +4143,29 @@ dependencies = [
  "num-traits 0.2.19",
  "rfc6979",
  "sha2",
- "starknet-crypto-codegen",
+ "starknet-crypto-codegen 0.3.3",
  "starknet-curve 0.4.2",
  "starknet-ff",
+ "zeroize",
+]
+
+[[package]]
+name = "starknet-crypto"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2a821ad8d98c6c3e4d0e5097f3fe6e2ed120ada9d32be87cd1330c7923a2f0"
+dependencies = [
+ "crypto-bigint",
+ "hex",
+ "hmac",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.19",
+ "rfc6979",
+ "sha2",
+ "starknet-crypto-codegen 0.4.0",
+ "starknet-curve 0.5.0",
+ "starknet-types-core",
  "zeroize",
 ]
 
@@ -4123,6 +4177,17 @@ checksum = "bbc159a1934c7be9761c237333a57febe060ace2bc9e3b337a59a37af206d19f"
 dependencies = [
  "starknet-curve 0.4.2",
  "starknet-ff",
+ "syn 2.0.75",
+]
+
+[[package]]
+name = "starknet-crypto-codegen"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e179dedc3fa6da064e56811d3e05d446aa2f7459e4eb0e3e49378a337235437"
+dependencies = [
+ "starknet-curve 0.5.0",
+ "starknet-types-core",
  "syn 2.0.75",
 ]
 
@@ -4142,6 +4207,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1c383518bb312751e4be80f53e8644034aa99a0afb29d7ac41b89a997db875b"
 dependencies = [
  "starknet-ff",
+]
+
+[[package]]
+name = "starknet-curve"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56935b306dcf0b8f14bb2a1257164b8478bb8be4801dfae0923f5b266d1b457c"
+dependencies = [
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -4264,7 +4338,7 @@ checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "phf_shared 0.10.0",
  "precomputed-hash",
 ]
@@ -4545,7 +4619,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -4709,6 +4783,16 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "triomphe"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6631e42e10b40c0690bf92f404ebcfe6e1fdb480391d15f17cc8e96eeed5369"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ starknet_api = "0.13.0-rc.0"
 blockifier = { git = "https://github.com/lambdaclass/blockifier", branch = "native2.8.x-adapt" }
 cairo-native = { git = "https://github.com/lambdaclass/cairo_native" }
 tracing = "0.1"
+
+[patch.'https://github.com/lambdaclass/cairo_native']
+cairo-native = { git = 'https://github.com/lambdaclass//cairo_native.git', rev = "4355357697e9ab57ab88ae3a4282aac61455619e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,14 @@ resolver = "2"
 
 [workspace.dependencies]
 thiserror = "1.0.32"
-starknet_api = "0.13.0-rc.0"
-blockifier = { git = "https://github.com/lambdaclass/blockifier", branch = "native2.8.x-adapt" }
+starknet_api = { git = "https://github.com/lambdaclass/sequencer" }
+blockifier = { git = "https://github.com/lambdaclass/sequencer" }
 cairo-native = { git = "https://github.com/lambdaclass/cairo_native" }
 tracing = "0.1"
 
 [patch.'https://github.com/lambdaclass/cairo_native']
 cairo-native = { git = 'https://github.com/lambdaclass//cairo_native.git', rev = "4355357697e9ab57ab88ae3a4282aac61455619e" }
+
+[patch.'https://github.com/lambdaclass/sequencer']
+blockifier = { path = '../sequencer/crates/blockifier' }
+starknet_api = { path = '../sequencer/crates/starknet_api' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ resolver = "2"
 
 [workspace.dependencies]
 thiserror = "1.0.32"
-starknet_api = { git = "https://github.com/lambdaclass/sequencer" }
-blockifier = { git = "https://github.com/lambdaclass/sequencer" }
+starknet_api = { git = "https://github.com/lambdaclass/sequencer", branch = "native2.8.x-arc"}
+blockifier = { git = "https://github.com/lambdaclass/sequencer", branch = "native2.8.x-arc"}
 cairo-native = { git = "https://github.com/lambdaclass/cairo_native" }
 tracing = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ resolver = "2"
 [workspace.dependencies]
 thiserror = "1.0.32"
 starknet_api = "0.13.0-rc.0"
-blockifier = { git = "https://github.com/lambdaclass/blockifier", branch= "native2.7.x-adapt" }
+blockifier = { git = "https://github.com/lambdaclass/blockifier", branch = "native2.8.x-adapt" }
+cairo-native = { git = "https://github.com/lambdaclass/cairo_native" }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,3 @@ tracing = "0.1"
 
 [patch.'https://github.com/lambdaclass/cairo_native']
 cairo-native = { git = 'https://github.com/lambdaclass//cairo_native.git', rev = "4355357697e9ab57ab88ae3a4282aac61455619e" }
-
-# [patch.'https://github.com/lambdaclass/sequencer']
-# blockifier = { path = '../sequencer/crates/blockifier' }
-# starknet_api = { path = '../sequencer/crates/starknet_api' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ tracing = "0.1"
 [patch.'https://github.com/lambdaclass/cairo_native']
 cairo-native = { git = 'https://github.com/lambdaclass//cairo_native.git', rev = "4355357697e9ab57ab88ae3a4282aac61455619e" }
 
-[patch.'https://github.com/lambdaclass/sequencer']
-blockifier = { path = '../sequencer/crates/blockifier' }
-starknet_api = { path = '../sequencer/crates/starknet_api' }
+# [patch.'https://github.com/lambdaclass/sequencer']
+# blockifier = { path = '../sequencer/crates/blockifier' }
+# starknet_api = { path = '../sequencer/crates/starknet_api' }

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -228,7 +228,7 @@ fn show_execution_data(
         );
     }
 
-    let execution_gas = execution_info.transaction_receipt.fee;
+    let execution_gas = execution_info.receipt.fee;
     let rpc_gas = rpc_receipt.actual_fee;
     debug!(?execution_gas, ?rpc_gas, "execution actual fee");
 }

--- a/rpc-state-reader/Cargo.toml
+++ b/rpc-state-reader/Cargo.toml
@@ -16,11 +16,11 @@ serde_json = { version = "1.0", features = [
   "raw_value",
 ] }
 starknet_api = {workspace = true}
-cairo-lang-starknet = "=2.7.1"
-cairo-lang-sierra = "=2.7.1"
-cairo-lang-starknet-classes = "=2.7.1"
-cairo-lang-utils = "=2.7.1"
-cairo-native = { git = "https://github.com/lambdaclass/cairo_native", branch = "cairo-lang2.7.0-rc.3" }
+cairo-lang-starknet = "2.8.0"
+cairo-lang-sierra = "2.8.0"
+cairo-lang-starknet-classes = "2.8.0"
+cairo-lang-utils = "2.8.0"
+cairo-native = { workspace = true }
 starknet = "0.7.0" 
 thiserror = { workspace = true }
 flate2 = "1.0.25"

--- a/rpc-state-reader/src/blockifier_state_reader.rs
+++ b/rpc-state-reader/src/blockifier_state_reader.rs
@@ -226,8 +226,7 @@ pub fn execute_tx(
     let blockifier_tx: AccountTransaction = match sn_api_tx.unwrap() {
         SNTransaction::Invoke(tx) => {
             let invoke = InvokeTransaction {
-                tx,
-                tx_hash,
+                tx: starknet_api::executable_transaction::InvokeTransaction { tx, tx_hash },
                 only_query: false,
             };
             AccountTransaction::Invoke(invoke)
@@ -242,9 +241,11 @@ pub fn execute_tx(
             .unwrap();
             AccountTransaction::DeployAccount(DeployAccountTransaction {
                 only_query: false,
-                tx,
-                tx_hash,
-                contract_address,
+                tx: starknet_api::executable_transaction::DeployAccountTransaction {
+                    tx,
+                    tx_hash,
+                    contract_address,
+                },
             })
         }
         SNTransaction::Declare(tx) => {
@@ -335,8 +336,10 @@ pub fn execute_tx_configurable_with_state(
     let blockifier_tx: AccountTransaction = match tx {
         SNTransaction::Invoke(tx) => {
             let invoke = InvokeTransaction {
-                tx,
-                tx_hash: *tx_hash,
+                tx: starknet_api::executable_transaction::InvokeTransaction {
+                    tx,
+                    tx_hash: *tx_hash,
+                },
                 only_query: false,
             };
             AccountTransaction::Invoke(invoke)
@@ -351,9 +354,11 @@ pub fn execute_tx_configurable_with_state(
             .unwrap();
             AccountTransaction::DeployAccount(DeployAccountTransaction {
                 only_query: false,
-                tx,
-                tx_hash: *tx_hash,
-                contract_address,
+                tx: starknet_api::executable_transaction::DeployAccountTransaction {
+                    tx,
+                    tx_hash: *tx_hash,
+                    contract_address,
+                },
             })
         }
         SNTransaction::Declare(tx) => {
@@ -441,8 +446,10 @@ pub fn execute_tx_with_blockifier(
     let account_transaction: AccountTransaction = match transaction {
         SNTransaction::Invoke(tx) => {
             let invoke = InvokeTransaction {
-                tx,
-                tx_hash: transaction_hash,
+                tx: starknet_api::executable_transaction::InvokeTransaction {
+                    tx,
+                    tx_hash: transaction_hash,
+                },
                 only_query: false,
             };
             AccountTransaction::Invoke(invoke)
@@ -457,9 +464,11 @@ pub fn execute_tx_with_blockifier(
             .unwrap();
             AccountTransaction::DeployAccount(DeployAccountTransaction {
                 only_query: false,
-                tx,
-                tx_hash: transaction_hash,
-                contract_address,
+                tx: starknet_api::executable_transaction::DeployAccountTransaction {
+                    tx,
+                    tx_hash: transaction_hash,
+                    contract_address,
+                },
             })
         }
         SNTransaction::Declare(tx) => {
@@ -544,7 +553,7 @@ mod tests {
 
         let price = rpc_state.get_gas_price(169928).unwrap();
         assert_eq!(
-            price.eth_l1_gas_price,
+            price.get_l1_gas_price_by_fee_type(&blockifier::transaction::objects::FeeType::Eth),
             NonZeroU128::new(22804578690).unwrap()
         );
     }
@@ -763,7 +772,7 @@ mod tests {
         "0x04ba569a40a866fd1cbb2f3d3ba37ef68fb91267a4931a377d6acc6e5a854f9a",
         648462,
         RpcChain::MainNet,
-        GasVector { l1_gas: 4646, l1_data_gas: 0 },
+        GasVector { l1_gas: 4646, l1_data_gas: 0, l2_gas: 0 },
         7,
         3,
         0,
@@ -780,7 +789,7 @@ mod tests {
         "0x0355059efee7a38ba1fd5aef13d261914608dce7bdfacad92a71e396f0ad7a77",
         661815,
         RpcChain::MainNet,
-        GasVector { l1_gas: 4646, l1_data_gas: 0 },
+        GasVector { l1_gas: 4646, l1_data_gas: 0, l2_gas: 0 },
         9,
         2,
         0,
@@ -797,7 +806,7 @@ mod tests {
         "0x05324bac55fb9fb53e738195c2dcc1e7fed1334b6db824665e3e984293bec95e",
         662246,
         RpcChain::MainNet,
-        GasVector { l1_gas: 4646, l1_data_gas: 0 },
+        GasVector { l1_gas: 4646, l1_data_gas: 0, l2_gas: 0 },
         9,
         2,
         0,
@@ -814,7 +823,7 @@ mod tests {
         "0x670321c71835004fcab639e871ef402bb807351d126ccc4d93075ff2c31519d",
         654001,
         RpcChain::MainNet,
-        GasVector { l1_gas: 4646, l1_data_gas: 0 },
+        GasVector { l1_gas: 4646, l1_data_gas: 0, l2_gas: 0 },
         7,
         2,
         0,
@@ -831,7 +840,7 @@ mod tests {
         "0x06962f11a96849ebf05cd222313858a93a8c5f300493ed6c5859dd44f5f2b4e3",  
         654770,
         RpcChain::MainNet,
-        GasVector { l1_gas: 4646, l1_data_gas: 0 },
+        GasVector { l1_gas: 4646, l1_data_gas: 0, l2_gas: 0 },
         7,
         2,
         0,
@@ -848,7 +857,7 @@ mod tests {
         "0x078b81326882ecd2dc6c5f844527c3f33e0cdb52701ded7b1aa4d220c5264f72",
         653019,
         RpcChain::MainNet,
-        GasVector { l1_gas: 11736, l1_data_gas: 0 },
+        GasVector { l1_gas: 11736, l1_data_gas: 0, l2_gas: 0 },
         28,
         2,
         0,
@@ -865,7 +874,7 @@ mod tests {
         "0x0780e3a498b4fd91ab458673891d3e8ee1453f9161f4bfcb93dd1e2c91c52e10",
         650558,
         RpcChain::MainNet,
-        GasVector { l1_gas: 6538, l1_data_gas: 0 },
+        GasVector { l1_gas: 6538, l1_data_gas: 0, l2_gas: 0 },
         24,
         3,
         0,
@@ -882,7 +891,7 @@ mod tests {
         "0x4f552c9430bd21ad300db56c8f4cae45d554a18fac20bf1703f180fac587d7e",
         351226,
         RpcChain::MainNet,
-        GasVector { l1_gas: 2754, l1_data_gas: 0 },
+        GasVector { l1_gas: 2754, l1_data_gas: 0, l2_gas: 0 },
         3,
         0,
         0,
@@ -899,7 +908,7 @@ mod tests {
         "0x176a92e8df0128d47f24eebc17174363457a956fa233cc6a7f8561bfbd5023a",
         317093,
         RpcChain::MainNet,
-        GasVector { l1_gas: 1652, l1_data_gas: 0 },
+        GasVector { l1_gas: 1652, l1_data_gas: 0, l2_gas: 0 },
         6,
         2,
         0,
@@ -916,7 +925,7 @@ mod tests {
         "0x026c17728b9cd08a061b1f17f08034eb70df58c1a96421e73ee6738ad258a94c",
         169929,
         RpcChain::MainNet,
-        GasVector { l1_gas: 1652, l1_data_gas: 0 },
+        GasVector { l1_gas: 1652, l1_data_gas: 0, l2_gas: 0 },
         8,
         2,
         0,
@@ -933,7 +942,7 @@ mod tests {
         "0x1088aa18785779e1e8eef406dc495654ad42a9729b57969ad0dbf2189c40bee",
         271888,
         RpcChain::MainNet,
-        GasVector { l1_gas: 1652, l1_data_gas: 0 },
+        GasVector { l1_gas: 1652, l1_data_gas: 0, l2_gas: 0 },
         0,
         2,
         42564,
@@ -950,7 +959,7 @@ mod tests {
         "0x73ef9cde09f005ff6f411de510ecad4cdcf6c4d0dfc59137cff34a4fc74dfd",
         654001,
         RpcChain::MainNet,
-        GasVector { l1_gas: 2754, l1_data_gas: 0 },
+        GasVector { l1_gas: 2754, l1_data_gas: 0, l2_gas: 0 },
         5,
         0,
         0,
@@ -967,7 +976,7 @@ mod tests {
         "0x0743092843086fa6d7f4a296a226ee23766b8acf16728aef7195ce5414dc4d84",
         186549,
         RpcChain::MainNet,
-        GasVector { l1_gas: 5748, l1_data_gas: 0 },
+        GasVector { l1_gas: 5748, l1_data_gas: 0, l2_gas: 0 },
         7,
         2,
         0,
@@ -984,7 +993,7 @@ mod tests {
         "0x066e1f01420d8e433f6ef64309adb1a830e5af0ea67e3d935de273ca57b3ae5e",
         662252,
         RpcChain::MainNet,
-        GasVector { l1_gas: 6850, l1_data_gas: 0 },
+        GasVector { l1_gas: 6850, l1_data_gas: 0, l2_gas: 0 },
         18,
         2,
         0,
@@ -1001,7 +1010,7 @@ mod tests {
         "0x04756d898323a8f884f5a6aabd6834677f4bbaeecc2522f18b3ae45b3f99cd1e",
         662250,
         RpcChain::MainNet,
-        GasVector { l1_gas: 1652, l1_data_gas: 0 },
+        GasVector { l1_gas: 1652, l1_data_gas: 0, l2_gas: 0 },
         10,
         2,
         0,
@@ -1018,7 +1027,7 @@ mod tests {
         "0x00f390691fd9e865f5aef9c7cc99889fb6c2038bc9b7e270e8a4fe224ccd404d",
         662251,
         RpcChain::MainNet,
-        GasVector { l1_gas: 3544, l1_data_gas: 0 },
+        GasVector { l1_gas: 3544, l1_data_gas: 0, l2_gas: 0 },
         12,
         5,
         0,
@@ -1035,7 +1044,7 @@ mod tests {
         "0x26be3e906db66973de1ca5eec1ddb4f30e3087dbdce9560778937071c3d3a83",
         351269,
         RpcChain::MainNet,
-        GasVector { l1_gas: 2754, l1_data_gas: 0 },
+        GasVector { l1_gas: 2754, l1_data_gas: 0, l2_gas: 0 },
         3,
         0,
         0,
@@ -1052,7 +1061,7 @@ mod tests {
         "0x0310c46edc795c82c71f600159fa9e6c6540cb294df9d156f685bfe62b31a5f4",
         662249,
         RpcChain::MainNet,
-        GasVector { l1_gas: 9844, l1_data_gas: 0 },
+        GasVector { l1_gas: 9844, l1_data_gas: 0, l2_gas: 0 },
         37,
         2,
         0,
@@ -1069,7 +1078,7 @@ mod tests {
         "0x06a09ffbf996178ac6e90101047e42fe29cb7108573b2ecf4b0ebd2cba544cb4",
         662248,
         RpcChain::MainNet,
-        GasVector { l1_gas: 5748, l1_data_gas: 0 },
+        GasVector { l1_gas: 5748, l1_data_gas: 0, l2_gas: 0 },
         4,
         2,
         0,
@@ -1086,7 +1095,7 @@ mod tests {
         "0x026e04e96ba1b75bfd066c8e138e17717ecb654909e6ac24007b644ac23e4b47",
         536893,
         RpcChain::MainNet,
-        GasVector { l1_gas: 13940, l1_data_gas: 0 },
+        GasVector { l1_gas: 13940, l1_data_gas: 0, l2_gas: 0 },
         24,
         4,
         0,
@@ -1103,7 +1112,7 @@ mod tests {
         "0x01351387ef63fd6fe5ec10fa57df9e006b2450b8c68d7eec8cfc7d220abc7eda",
         644700,
         RpcChain::MainNet,
-        GasVector { l1_gas: 1652, l1_data_gas: 0 },
+        GasVector { l1_gas: 1652, l1_data_gas: 0, l2_gas: 0 },
         8,
         2,
         0,
@@ -1131,7 +1140,7 @@ mod tests {
     ) {
         let previous_block = BlockNumber(block_number - 1);
         let (tx_info, _, _) = execute_tx(hash, chain, previous_block);
-        let tx_receipt = tx_info.transaction_receipt;
+        let tx_receipt = tx_info.receipt;
         let starknet_resources = tx_receipt.resources.starknet_resources;
         let callinfo_iter = match tx_info.execute_call_info {
             Some(c) => vec![c],

--- a/rpc-state-reader/src/blockifier_state_reader.rs
+++ b/rpc-state-reader/src/blockifier_state_reader.rs
@@ -383,9 +383,7 @@ pub fn execute_tx_configurable_with_state(
         _ => unimplemented!(),
     };
 
-    let blockifier_execution = blockifier_tx.execute(state, &block_context, false, true);
-
-    blockifier_execution
+    blockifier_tx.execute(state, &block_context, false, true)
 }
 
 pub fn execute_tx_configurable(

--- a/rpc-state-reader/src/blockifier_state_reader.rs
+++ b/rpc-state-reader/src/blockifier_state_reader.rs
@@ -383,7 +383,6 @@ pub fn execute_tx_configurable_with_state(
         _ => unimplemented!(),
     };
 
-    #[cfg(not(feature = "cairo-native"))]
     let blockifier_execution = blockifier_tx.execute(state, &block_context, false, true);
 
     blockifier_execution

--- a/rpc-state-reader/src/lib.rs
+++ b/rpc-state-reader/src/lib.rs
@@ -114,8 +114,7 @@ mod tests {
         match tx {
             SNTransaction::Invoke(tx) => {
                 let invoke = InvokeTransaction {
-                    tx,
-                    tx_hash,
+                    tx: starknet_api::executable_transaction::InvokeTransaction { tx, tx_hash },
                     only_query: false,
                 };
                 AccountTransaction::Invoke(invoke)

--- a/rpc-state-reader/src/rpc_state.rs
+++ b/rpc-state-reader/src/rpc_state.rs
@@ -488,17 +488,39 @@ impl RpcState {
         )
         .map_err(|_| RpcStateError::RpcResponseWrongType("l1_data_gas_price".to_string()))?;
 
+        let l2_gas_price_eth = u128::from_str_radix(
+            res.get("l2_gas_price")
+                .and_then(|gp| gp.get("price_in_wei"))
+                .and_then(|gp| gp.as_str())
+                .ok_or(RpcStateError::MissingRpcResponseField(
+                    "gas_price.price_in_wei".to_string(),
+                ))?
+                .trim_start_matches("0x"),
+            16,
+        )
+        .map_err(|_| RpcStateError::RpcResponseWrongType("gas_price".to_string()))?;
+
+        let l2_gas_price_strk = u128::from_str_radix(
+            res.get("l2_gas_price")
+                .and_then(|gp| gp.get("price_in_fri"))
+                .and_then(|gp| gp.as_str())
+                .ok_or(RpcStateError::MissingRpcResponseField(
+                    "gas_price.price_in_fri".to_string(),
+                ))?
+                .trim_start_matches("0x"),
+            16,
+        )
+        .map_err(|_| RpcStateError::RpcResponseWrongType("gas_price".to_string()))?;
+
         // TODO check 0 wei/strk
-        Ok(GasPrices {
-            eth_l1_gas_price: NonZeroU128::new(gas_price_eth)
-                .unwrap_or(NonZeroU128::new(1).unwrap()),
-            strk_l1_gas_price: NonZeroU128::new(gas_price_strk)
-                .unwrap_or(NonZeroU128::new(1).unwrap()),
-            eth_l1_data_gas_price: NonZeroU128::new(l1_data_gas_price_wei)
-                .unwrap_or(NonZeroU128::new(1).unwrap()),
-            strk_l1_data_gas_price: NonZeroU128::new(l1_data_gas_price_strk)
-                .unwrap_or(NonZeroU128::new(1).unwrap()),
-        })
+        Ok(GasPrices::new(
+            NonZeroU128::new(gas_price_eth).unwrap_or(NonZeroU128::new(1).unwrap()),
+            NonZeroU128::new(gas_price_strk).unwrap_or(NonZeroU128::new(1).unwrap()),
+            NonZeroU128::new(l1_data_gas_price_wei).unwrap_or(NonZeroU128::new(1).unwrap()),
+            NonZeroU128::new(l1_data_gas_price_strk).unwrap_or(NonZeroU128::new(1).unwrap()),
+            NonZeroU128::new(l2_gas_price_eth).unwrap_or(NonZeroU128::new(1).unwrap()),
+            NonZeroU128::new(l2_gas_price_strk).unwrap_or(NonZeroU128::new(1).unwrap()),
+        ))
     }
 
     pub fn get_chain_name(&self) -> ChainId {

--- a/rpc-state-reader/src/rpc_state.rs
+++ b/rpc-state-reader/src/rpc_state.rs
@@ -488,38 +488,14 @@ impl RpcState {
         )
         .map_err(|_| RpcStateError::RpcResponseWrongType("l1_data_gas_price".to_string()))?;
 
-        let l2_gas_price_eth = u128::from_str_radix(
-            res.get("l2_gas_price")
-                .and_then(|gp| gp.get("price_in_wei"))
-                .and_then(|gp| gp.as_str())
-                .ok_or(RpcStateError::MissingRpcResponseField(
-                    "gas_price.price_in_wei".to_string(),
-                ))?
-                .trim_start_matches("0x"),
-            16,
-        )
-        .map_err(|_| RpcStateError::RpcResponseWrongType("gas_price".to_string()))?;
-
-        let l2_gas_price_strk = u128::from_str_radix(
-            res.get("l2_gas_price")
-                .and_then(|gp| gp.get("price_in_fri"))
-                .and_then(|gp| gp.as_str())
-                .ok_or(RpcStateError::MissingRpcResponseField(
-                    "gas_price.price_in_fri".to_string(),
-                ))?
-                .trim_start_matches("0x"),
-            16,
-        )
-        .map_err(|_| RpcStateError::RpcResponseWrongType("gas_price".to_string()))?;
-
         // TODO check 0 wei/strk
         Ok(GasPrices::new(
             NonZeroU128::new(gas_price_eth).unwrap_or(NonZeroU128::new(1).unwrap()),
             NonZeroU128::new(gas_price_strk).unwrap_or(NonZeroU128::new(1).unwrap()),
             NonZeroU128::new(l1_data_gas_price_wei).unwrap_or(NonZeroU128::new(1).unwrap()),
             NonZeroU128::new(l1_data_gas_price_strk).unwrap_or(NonZeroU128::new(1).unwrap()),
-            NonZeroU128::new(l2_gas_price_eth).unwrap_or(NonZeroU128::new(1).unwrap()),
-            NonZeroU128::new(l2_gas_price_strk).unwrap_or(NonZeroU128::new(1).unwrap()),
+            NonZeroU128::new(1).unwrap(),
+            NonZeroU128::new(1).unwrap(),
         ))
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.80.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
This PR changes the dependency blockifier to point to: https://github.com/lambdaclass/sequencer/tree/native2.8.x-arc/crates/blockifier. I created a new branch [native2.8.x-arc](https://github.com/lambdaclass/sequencer/compare/native2.7.x...lambdaclass:sequencer:native2.8.x-arc) that uses Cairo 2.8 and `Arc<AotNativeExecutor>`.

This PR continued upon #45, so we can close that one and merge this one instead.