### PR TITLE
Add extra info to transactions logs

### DIFF
--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -290,6 +290,12 @@ fn show_execution_data(
         rpc_receipt.messages_sent.len(),
     );
 
+    let events_match = exec_rsc.n_events == rpc_receipt.events.len();
+    let msgs_match = rpc_receipt.messages_sent.len()
+        == exec_rsc.message_cost_info.l2_to_l1_payload_lengths.len();
+
+    let events_msgs_match = events_match && msgs_match;
+
     let state_changes = exec_rsc.state_changes_for_fee;
     let state_changes_for_fee_str = format!(
         "{{ n_class_hash_updates: {}, n_compiled_class_hash_updates: {}, n_modified_contracts: {}, n_storage_updates: {} }}",
@@ -299,7 +305,7 @@ fn show_execution_data(
         state_changes.n_storage_updates
     );
 
-    if !status_matches {
+    if !status_matches || !events_msgs_match {
         error!(
             transaction_hash = tx_hash,
             chain = chain,

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -214,24 +214,30 @@ fn show_execution_data(
         da_gas.l1_data_gas, da_gas.l1_gas
     );
 
-    let resources = &execution_info
+    let exec_rsc = &execution_info
         .transaction_receipt
         .resources
         .starknet_resources;
-    let resources_str = format!(
+
+    let events_and_msgs = format!(
         "{{ events_number: {}, l2_to_l1_messages_number: {} }}",
-        resources.n_events,
-        resources.message_cost_info.l2_to_l1_payload_lengths.len(),
+        exec_rsc.n_events,
+        exec_rsc.message_cost_info.l2_to_l1_payload_lengths.len(),
+    );
+    let rpc_events_and_msgs = format!(
+        "{{ events_number: {}, l2_to_l1_messages_number: {} }}",
+        rpc_receipt.events.len(),
+        rpc_receipt.messages_sent.len(),
     );
 
-    let state_changes = resources.state_changes_for_fee;
-    let state_changes_for_fee_str = format!(
-        "{{ n_class_hash_updates: {}, n_compiled_class_hash_updates: {}, n_modified_contracts: {}, n_storage_updates: {} }}",
-        state_changes.n_class_hash_updates,
-        state_changes.n_compiled_class_hash_updates,
-        state_changes.n_modified_contracts,
-        state_changes.n_storage_updates
-    );
+    // let state_changes = resources.state_changes_for_fee;
+    // let state_changes_for_fee_str = format!(
+    //     "{{ n_class_hash_updates: {}, n_compiled_class_hash_updates: {}, n_modified_contracts: {}, n_storage_updates: {} }}",
+    //     state_changes.n_class_hash_updates,
+    //     state_changes.n_compiled_class_hash_updates,
+    //     state_changes.n_modified_contracts,
+    //     state_changes.n_storage_updates
+    // );
 
     if !status_matches {
         error!(
@@ -240,9 +246,9 @@ fn show_execution_data(
             execution_status,
             rpc_execution_status,
             execution_error_message = execution_info.revert_error,
+            events_and_messages = events_and_msgs,
+            rpc_events_and_msgs = rpc_events_and_msgs,
             da_gas = da_gas_str,
-            starknet_events_and_messages = resources_str,
-            state_changes_for_fee = state_changes_for_fee_str,
             "rpc and execution status diverged"
         )
     } else {
@@ -252,9 +258,9 @@ fn show_execution_data(
             execution_status,
             rpc_execution_status,
             execution_error_message = execution_info.revert_error,
+            n_eventsevents_and_messages = events_and_msgs,
+            rpc_n_events_and_msgs = rpc_events_and_msgs,
             da_gas = da_gas_str,
-            starknet_resources = resources_str,
-            state_changes_for_fee = state_changes_for_fee_str,
             "execution finished successfully"
         );
     }

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -227,14 +227,14 @@ fn show_execution_data(
         rpc_receipt.messages_sent.len(),
     );
 
-    // let state_changes = resources.state_changes_for_fee;
-    // let state_changes_for_fee_str = format!(
-    //     "{{ n_class_hash_updates: {}, n_compiled_class_hash_updates: {}, n_modified_contracts: {}, n_storage_updates: {} }}",
-    //     state_changes.n_class_hash_updates,
-    //     state_changes.n_compiled_class_hash_updates,
-    //     state_changes.n_modified_contracts,
-    //     state_changes.n_storage_updates
-    // );
+    let state_changes = exec_rsc.state_changes_for_fee;
+    let state_changes_for_fee_str = format!(
+        "{{ n_class_hash_updates: {}, n_compiled_class_hash_updates: {}, n_modified_contracts: {}, n_storage_updates: {} }}",
+        state_changes.n_class_hash_updates,
+        state_changes.n_compiled_class_hash_updates,
+        state_changes.n_modified_contracts,
+        state_changes.n_storage_updates
+    );
 
     if !status_matches {
         error!(
@@ -246,6 +246,7 @@ fn show_execution_data(
             events_and_messages = events_and_msgs,
             rpc_events_and_msgs = rpc_events_and_msgs,
             da_gas = da_gas_str,
+            state_changes_for_fee_str,
             "rpc and execution status diverged"
         )
     } else {
@@ -258,6 +259,7 @@ fn show_execution_data(
             n_eventsevents_and_messages = events_and_msgs,
             rpc_n_events_and_msgs = rpc_events_and_msgs,
             da_gas = da_gas_str,
+            state_changes_for_fee_str,
             "execution finished successfully"
         );
     }

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -208,16 +208,13 @@ fn show_execution_data(
     let rpc_execution_status = rpc_receipt.execution_status;
     let status_matches = execution_status == rpc_execution_status;
 
-    let da_gas = &execution_info.transaction_receipt.da_gas;
+    let da_gas = &execution_info.receipt.da_gas;
     let da_gas_str = format!(
         "{{ l1_da_gas: {}, l1_gas: {} }}",
         da_gas.l1_data_gas, da_gas.l1_gas
     );
 
-    let exec_rsc = &execution_info
-        .transaction_receipt
-        .resources
-        .starknet_resources;
+    let exec_rsc = &execution_info.receipt.resources.starknet_resources;
 
     let events_and_msgs = format!(
         "{{ events_number: {}, l2_to_l1_messages_number: {} }}",

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -243,8 +243,8 @@ fn show_execution_data(
             execution_status,
             rpc_execution_status,
             execution_error_message = execution_info.revert_error,
-            events_and_messages = events_and_msgs,
-            rpc_events_and_msgs = rpc_events_and_msgs,
+            n_events_and_messages = events_and_msgs,
+            rpc_n_events_and_msgs = rpc_events_and_msgs,
             da_gas = da_gas_str,
             state_changes_for_fee_str,
             "rpc and execution status diverged"

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -208,6 +208,31 @@ fn show_execution_data(
     let rpc_execution_status = rpc_receipt.execution_status;
     let status_matches = execution_status == rpc_execution_status;
 
+    let da_gas = &execution_info.transaction_receipt.da_gas;
+    let da_gas_str = format!(
+        "{{ l1_da_gas: {}, l1_gas: {} }}",
+        da_gas.l1_data_gas, da_gas.l1_gas
+    );
+
+    let resources = &execution_info
+        .transaction_receipt
+        .resources
+        .starknet_resources;
+    let resources_str = format!(
+        "{{ events_number: {}, l2_to_l1_messages_number: {} }}",
+        resources.n_events,
+        resources.message_cost_info.l2_to_l1_payload_lengths.len(),
+    );
+
+    let state_changes = resources.state_changes_for_fee;
+    let state_changes_for_fee_str = format!(
+        "{{ n_class_hash_updates: {}, n_compiled_class_hash_updates: {}, n_modified_contracts: {}, n_storage_updates: {} }}",
+        state_changes.n_class_hash_updates,
+        state_changes.n_compiled_class_hash_updates,
+        state_changes.n_modified_contracts,
+        state_changes.n_storage_updates
+    );
+
     if !status_matches {
         error!(
             transaction_hash = tx_hash,
@@ -215,6 +240,9 @@ fn show_execution_data(
             execution_status,
             rpc_execution_status,
             execution_error_message = execution_info.revert_error,
+            da_gas = da_gas_str,
+            starknet_events_and_messages = resources_str,
+            state_changes_for_fee = state_changes_for_fee_str,
             "rpc and execution status diverged"
         )
     } else {
@@ -224,6 +252,9 @@ fn show_execution_data(
             execution_status,
             rpc_execution_status,
             execution_error_message = execution_info.revert_error,
+            da_gas = da_gas_str,
+            starknet_resources = resources_str,
+            state_changes_for_fee = state_changes_for_fee_str,
             "execution finished successfully"
         );
     }

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -256,7 +256,7 @@ fn show_execution_data(
             execution_status,
             rpc_execution_status,
             execution_error_message = execution_info.revert_error,
-            n_eventsevents_and_messages = events_and_msgs,
+            n_events_and_messages = events_and_msgs,
             rpc_n_events_and_msgs = rpc_events_and_msgs,
             da_gas = da_gas_str,
             state_changes_for_fee_str,

--- a/rpc-state-reader/src/rpc_state.rs
+++ b/rpc-state-reader/src/rpc_state.rs
@@ -172,6 +172,8 @@ pub struct RpcTransactionReceipt {
     pub block_hash: StarkHash,
     pub block_number: u64,
     pub execution_status: String,
+    pub events: Vec<Event>,
+    pub messages_sent: Vec<ToL1Msg>,
     #[serde(rename = "type")]
     pub tx_type: String,
     #[serde(deserialize_with = "vm_execution_resources_deser")]
@@ -184,6 +186,22 @@ pub struct FeePayment {
     #[serde(deserialize_with = "fee_amount_deser")]
     pub amount: u128,
     pub unit: String,
+}
+
+#[allow(unused)]
+#[derive(Debug, Deserialize)]
+pub struct Event {
+    from_address: StarkHash,
+    keys: Vec<StarkHash>,
+    data: Vec<StarkHash>
+}
+
+#[allow(unused)]
+#[derive(Debug, Deserialize)]
+pub struct ToL1Msg {
+    from_address: StarkHash,
+    to_address: StarkHash,
+    payload: Vec<StarkHash>
 }
 
 fn fee_amount_deser<'de, D>(deserializer: D) -> Result<u128, D::Error>

--- a/rpc-state-reader/src/rpc_state.rs
+++ b/rpc-state-reader/src/rpc_state.rs
@@ -193,7 +193,7 @@ pub struct FeePayment {
 pub struct Event {
     from_address: StarkHash,
     keys: Vec<StarkHash>,
-    data: Vec<StarkHash>
+    data: Vec<StarkHash>,
 }
 
 #[allow(unused)]
@@ -201,7 +201,7 @@ pub struct Event {
 pub struct ToL1Msg {
     from_address: StarkHash,
     to_address: StarkHash,
-    payload: Vec<StarkHash>
+    payload: Vec<StarkHash>,
 }
 
 fn fee_amount_deser<'de, D>(deserializer: D) -> Result<u128, D::Error>


### PR DESCRIPTION
This PR adds the resources, events and messages used during transactions to the logs. It adds: 
1. The amounts of l2 to l1 messages and events that happened during the transaction.
2. The data availability gas consumed.
3. The state changed that happend: `n_class_hash_updates`, `n_compiled_class_hash_updates` ,`n_modified_contracts`, `n_storage_updates`.

The only ones that can be matched with the rpc are the events and the messages since those are returned by the rpc.

Currently, the blockifier is not counting the event's number correctly (or that's what I'm supposing) since they differ in 1 with the rpc result. My guess is that this due to an error in the implementation which only takes into account the events produced by the inner_calls and does not count the ones generated by the contract itself. [here](https://github.com/starkware-libs/sequencer/blob/main/crates/blockifier/src/transaction/objects.rs#L458)
