### PR TITLE
Add error reason to the logs

### DIFF
--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -306,11 +306,24 @@ fn show_execution_data(
     );
 
     if !status_matches || !events_msgs_match {
+        let root_of_error = if !status_matches {
+            "EXECUTION STATUS DIVERGED"
+        } else if !events_match {
+            "EVENT COUNT DIVERGED"
+        } else if !msgs_match {
+            "MESSAGE COUNT DIVERGED"
+        } else if !(events_match || msgs_match) {
+            "MESSAGE AND EVENT COUNT DIVERGED"
+        } else {
+            unreachable!()
+        };
+        
         error!(
             transaction_hash = tx_hash,
             chain = chain,
             execution_status,
             rpc_execution_status,
+            root_of_error = root_of_error,
             execution_error_message = execution_info.revert_error,
             n_events_and_messages = events_and_msgs,
             rpc_n_events_and_msgs = rpc_events_and_msgs,

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -290,6 +290,8 @@ fn show_execution_data(
         rpc_receipt.messages_sent.len(),
     );
 
+    // currently adding 1 because the sequencer is counting only the
+    // events produced by the inner calls of a callinfo
     let events_match = exec_rsc.n_events + 1 == rpc_receipt.events.len();
     let msgs_match = rpc_receipt.messages_sent.len()
         == exec_rsc.message_cost_info.l2_to_l1_payload_lengths.len();

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -281,7 +281,7 @@ fn show_execution_data(
 
     let events_and_msgs = format!(
         "{{ events_number: {}, l2_to_l1_messages_number: {} }}",
-        exec_rsc.n_events,
+        exec_rsc.n_events + 1,
         exec_rsc.message_cost_info.l2_to_l1_payload_lengths.len(),
     );
     let rpc_events_and_msgs = format!(
@@ -290,7 +290,7 @@ fn show_execution_data(
         rpc_receipt.messages_sent.len(),
     );
 
-    let events_match = exec_rsc.n_events == rpc_receipt.events.len();
+    let events_match = exec_rsc.n_events + 1 == rpc_receipt.events.len();
     let msgs_match = rpc_receipt.messages_sent.len()
         == exec_rsc.message_cost_info.l2_to_l1_payload_lengths.len();
 

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -308,14 +308,12 @@ fn show_execution_data(
     if !status_matches || !events_msgs_match {
         let root_of_error = if !status_matches {
             "EXECUTION STATUS DIVERGED"
-        } else if !events_match {
-            "EVENT COUNT DIVERGED"
-        } else if !msgs_match {
-            "MESSAGE COUNT DIVERGED"
         } else if !(events_match || msgs_match) {
             "MESSAGE AND EVENT COUNT DIVERGED"
+        } else if !events_match {
+            "EVENT COUNT DIVERGED"
         } else {
-            unreachable!()
+            "MESSAGE COUNT DIVERGED"
         };
         
         error!(

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -315,7 +315,7 @@ fn show_execution_data(
         } else {
             "MESSAGE COUNT DIVERGED"
         };
-        
+
         error!(
             transaction_hash = tx_hash,
             chain = chain,


### PR DESCRIPTION
This PR adds the root of the error, if it was the case. It could be because the execution status diverged or the events and messages count. Due to this, it shows which one of the four ( there could be a case where both events and messages count fail) has happend, having more precedence the execution status error.