### PR TITLE
change quotes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ serde_with = "3.9.0"
 serde = "1.0.197"
 
 [patch.'https://github.com/lambdaclass/cairo_native']
-cairo-native = { git = 'https://github.com/lambdaclass//cairo_native.git', rev = "355c250f37cf0977ef2776b1aae2cb2e87c9da3d" }
+cairo-native = { git = "https://github.com/lambdaclass//cairo_native.git", rev = "355c250f37cf0977ef2776b1aae2cb2e87c9da3d" }


### PR DESCRIPTION
Changes single quotes to double quotes. Since we are mostly using double quotes, I changed it to prevent incompatibilities when patching the cairo_native's version during the blocks running in the ci. 