### PR TITLE
Dump state also on error

### DIFF
--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -277,24 +277,20 @@ fn show_execution_data(
 
     let previous_block_number = BlockNumber(block_number - 1);
 
-    let execution_info = match execute_tx_configurable(
+    let execution_info = execute_tx_configurable(
         state,
         &tx_hash,
         previous_block_number,
         false,
         true,
         charge_fee,
-    ) {
-        Ok(x) => x,
-        Err(error_reason) => {
-            error!("execution failed unexpectedly: {}", error_reason);
-            return;
-        }
-    };
+    );
 
     #[cfg(feature = "state_dump")]
     {
+        use std::fs::File;
         use std::path::Path;
+
         #[cfg(feature = "only_cairo_vm")]
         let root = Path::new("state_dumps/vm");
         #[cfg(not(feature = "only_cairo_vm"))]
@@ -304,8 +300,26 @@ fn show_execution_data(
         let mut path = root.join(&tx_hash);
         path.set_extension("json");
 
-        state_dump::dump_state_diff(state, &execution_info, &path).unwrap();
+        match &execution_info {
+            Ok(execution_info) => {
+                state_dump::dump_state_diff(state, execution_info, &path).unwrap();
+            }
+            Err(err) => {
+                // If we have no execution info, we write the error to a file so that it can be compared anyway
+                let file = File::create(path).unwrap();
+                let err = err.to_string();
+                serde_json::to_writer_pretty(file, &err).unwrap();
+            }
+        }
     }
+
+    let execution_info = match execution_info {
+        Ok(x) => x,
+        Err(error_reason) => {
+            error!("execution failed unexpectedly: {}", error_reason);
+            return;
+        }
+    };
 
     let transaction_hash = TransactionHash(StarkHash::from_hex(&tx_hash).unwrap());
     match state.state.get_transaction_receipt(&transaction_hash) {

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -316,7 +316,7 @@ fn show_execution_data(
     let execution_info = match execution_info {
         Ok(x) => x,
         Err(error_reason) => {
-            error!("execution failed unexpectedly: {}", error_reason);
+            error!("execution failed: {}", error_reason);
             return;
         }
     };


### PR DESCRIPTION
Closes #72

This PR writes the execution error to the state dump if it fails to complete. For example, the following command:
```bash
cargo run --features state_dump,only_cairo_vm tx 0x01438d65c0b7f923b9cd40b52341b99c1061ac5dc0ab97720d798b8d0ce0f882 mainnet 724000
```

Will generate the following file:
```bash
> cat state_dumps/vm/block724000/0x01438d65c0b7f923b9cd40b52341b99c1061ac5dc0ab97720d798b8d0ce0f882.json 
"Invalid transaction nonce of contract at address 0x066be86a31e7a708e17a2f813073fd489f661cf6fa4d949d2c3c8d59e7003a74. Account nonce: 0x00000000000000000000000000000000000000000000000000000000000000db; got: 0x00000000000000000000000000000000000000000000000000000000000000dc."⏎ 
```

Rather than generating nothing