### PR TITLE
Fix cmp order of `delta_state_dumps.sh`

### DIFF
--- a/scripts/delta_state_dumps.sh
+++ b/scripts/delta_state_dumps.sh
@@ -19,7 +19,7 @@ for block in state_dumps/vm/*/; do
 
   # Compares the files in ascending order, by creation date
   IFS=$'\n'
-  for tx_name in $(ls -trU1 $block); do
+  for tx_name in $(ls -tr1 $block); do
     native_tx="state_dumps/native/$block_name/$tx_name"
     vm_tx="state_dumps/vm/$block_name/$tx_name"
 


### PR DESCRIPTION
Closes #70

Removes the `U` flag, as it doesn't work in Linux.