### PR TITLE
Add cache to RPC Calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6167,6 +6167,7 @@ dependencies = [
  "pretty_assertions_sorted",
  "serde",
  "serde_json",
+ "serde_with 3.11.0",
  "sierra-emu",
  "starknet",
  "starknet_api",

--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -11,6 +11,7 @@ use blockifier::{
     },
 };
 use rpc_state_reader::{
+    cache::RpcCachedStateReader,
     execution::{fetch_block_context, fetch_blockifier_transaction},
     reader::{RpcChain, RpcStateReader},
 };
@@ -47,6 +48,7 @@ pub fn fetch_block_range_data(
         // For each block
         let block_number = BlockNumber(block_number);
         let reader = RpcStateReader::new(chain, block_number);
+        let reader = RpcCachedStateReader::new(reader);
 
         // Fetch block context
         let block_context = fetch_block_context(&reader).unwrap();
@@ -171,6 +173,7 @@ fn get_class_executions(call: CallInfo) -> Vec<ClassExecutionInfo> {
 
 pub fn fetch_transaction_data(tx: &str, block: BlockNumber, chain: RpcChain) -> BlockCachedData {
     let reader = RpcStateReader::new(chain, block);
+    let reader = RpcCachedStateReader::new(reader);
 
     // Fetch block context
     let block_context = fetch_block_context(&reader).unwrap();

--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -3,7 +3,7 @@ use std::{error::Error, fs::File, path::Path, time::Duration};
 use blockifier::{
     context::BlockContext,
     execution::{call_info::CallInfo, contract_class::RunnableCompiledClass},
-    state::{cached_state::CachedState, state_api::StateReader},
+    state::{cached_state::CachedState, state_api::StateReader as BlockifierStateReader},
     transaction::{
         account_transaction::ExecutionFlags, objects::TransactionExecutionInfo,
         transaction_execution::Transaction as BlockiTransaction,
@@ -13,7 +13,7 @@ use blockifier::{
 use rpc_state_reader::{
     cache::RpcCachedStateReader,
     execution::{fetch_block_context, fetch_blockifier_transaction},
-    reader::{RpcChain, RpcStateReader},
+    reader::{RpcChain, RpcStateReader, StateReader},
 };
 use serde::Serialize;
 use starknet_api::{
@@ -200,9 +200,9 @@ pub fn fetch_transaction_data(tx: &str, block: BlockNumber, chain: RpcChain) -> 
 /// An implementation of StateReader that can be disabled, panicking if atempted to be read from
 ///
 /// Used to ensure that no requests are made after disabling it.
-pub struct OptionalStateReader<S: StateReader>(pub Option<S>);
+pub struct OptionalStateReader<S: BlockifierStateReader>(pub Option<S>);
 
-impl<S: StateReader> OptionalStateReader<S> {
+impl<S: BlockifierStateReader> OptionalStateReader<S> {
     pub fn new(state_reader: S) -> Self {
         Self(Some(state_reader))
     }
@@ -218,7 +218,7 @@ impl<S: StateReader> OptionalStateReader<S> {
     }
 }
 
-impl<S: StateReader> StateReader for OptionalStateReader<S> {
+impl<S: BlockifierStateReader> BlockifierStateReader for OptionalStateReader<S> {
     fn get_storage_at(
         &self,
         contract_address: starknet_api::core::ContractAddress,

--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -47,8 +47,7 @@ pub fn fetch_block_range_data(
     for block_number in block_start.0..=block_end.0 {
         // For each block
         let block_number = BlockNumber(block_number);
-        let reader = RpcStateReader::new(chain, block_number);
-        let reader = RpcCachedStateReader::new(reader);
+        let reader = RpcCachedStateReader::new(RpcStateReader::new(chain, block_number));
 
         // Fetch block context
         let block_context = fetch_block_context(&reader).unwrap();
@@ -172,8 +171,7 @@ fn get_class_executions(call: CallInfo) -> Vec<ClassExecutionInfo> {
 }
 
 pub fn fetch_transaction_data(tx: &str, block: BlockNumber, chain: RpcChain) -> BlockCachedData {
-    let reader = RpcStateReader::new(chain, block);
-    let reader = RpcCachedStateReader::new(reader);
+    let reader = RpcCachedStateReader::new(RpcStateReader::new(chain, block));
 
     // Fetch block context
     let block_context = fetch_block_context(&reader).unwrap();

--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -25,7 +25,7 @@ use starknet_api::{
 };
 
 pub type BlockCachedData = (
-    CachedState<OptionalStateReader<RpcStateReader>>,
+    CachedState<OptionalStateReader<RpcCachedStateReader>>,
     BlockContext,
     Vec<BlockiTransaction>,
 );
@@ -69,7 +69,8 @@ pub fn fetch_block_range_data(
 
         // Create cached state
         let previous_block_number = block_number.prev().unwrap();
-        let previous_reader = RpcStateReader::new(chain, previous_block_number);
+        let previous_reader =
+            RpcCachedStateReader::new(RpcStateReader::new(chain, previous_block_number));
         let cached_state = CachedState::new(OptionalStateReader::new(previous_reader));
 
         block_caches.push((cached_state, block_context, transactions));
@@ -189,7 +190,8 @@ pub fn fetch_transaction_data(tx: &str, block: BlockNumber, chain: RpcChain) -> 
 
     // Create cached state
     let previous_block_number = block.prev().unwrap();
-    let previous_reader = RpcStateReader::new(chain, previous_block_number);
+    let previous_reader =
+        RpcCachedStateReader::new(RpcStateReader::new(chain, previous_block_number));
     let cached_state = CachedState::new(OptionalStateReader::new(previous_reader));
 
     (cached_state, block_context, transactions)

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -502,16 +502,6 @@ fn compare_execution(
     }
 }
 
-fn get_transaction_hashes(
-    network: &str,
-    block_number: u64,
-) -> Result<Vec<TransactionHash>, StateError> {
-    let network = parse_network(network);
-    let block_value = BlockNumber(block_number);
-    let rpc_state = RpcStateReader::new(network, block_value);
-    Ok(rpc_state.get_block_with_tx_hashes()?.transactions)
-}
-
 fn set_global_subscriber() {
     #[cfg(not(feature = "structured_logging"))]
     let default_env_filter =

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -103,9 +103,7 @@ fn main() {
             charge_fee,
         } => {
             let mut state = build_cached_state(&chain, block_number - 1);
-            state.state.load();
             show_execution_data(&mut state, tx_hash, &chain, block_number, charge_fee);
-            state.state.save();
         }
         ReplayExecute::Block {
             block_number,
@@ -115,7 +113,6 @@ fn main() {
             let _block_span = info_span!("block", number = block_number).entered();
 
             let mut state = build_cached_state(&chain, block_number - 1);
-            state.state.load();
 
             let transaction_hashes = get_transaction_hashes(&chain, block_number)
                 .expect("Unable to fetch the transaction hashes.");
@@ -128,8 +125,6 @@ fn main() {
                     charge_fee,
                 );
             }
-
-            state.state.save();
         }
         ReplayExecute::BlockRange {
             block_start,

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -105,7 +105,14 @@ fn main() {
             let mut state = build_cached_state(&chain, block_number - 1);
             let reader = build_reader(&chain, block_number);
 
-            show_execution_data(&mut state, &reader, tx_hash, &chain, charge_fee);
+            show_execution_data(
+                &mut state,
+                &reader,
+                tx_hash,
+                &chain,
+                block_number,
+                charge_fee,
+            );
         }
         ReplayExecute::Block {
             block_number,
@@ -127,6 +134,7 @@ fn main() {
                     &reader,
                     tx_hash.0.to_hex_string(),
                     &chain,
+                    block_number,
                     charge_fee,
                 );
             }
@@ -155,6 +163,7 @@ fn main() {
                         &reader,
                         tx_hash.0.to_hex_string(),
                         &chain,
+                        block_number,
                         charge_fee,
                     );
                 }
@@ -314,10 +323,11 @@ fn build_reader(network: &str, block_number: u64) -> RpcCachedStateReader {
 }
 
 fn show_execution_data(
-    state: &mut CachedState<RpcCachedStateReader>,
-    reader: &RpcCachedStateReader,
+    state: &mut CachedState<impl StateReader>,
+    reader: &impl StateReader,
     tx_hash_str: String,
     chain_str: &str,
+    block_number: u64,
     charge_fee: bool,
 ) {
     let _transaction_execution_span =
@@ -325,6 +335,7 @@ fn show_execution_data(
     info!("starting execution");
 
     let tx_hash = TransactionHash(felt!(tx_hash_str.as_str()));
+    let block_number = BlockNumber(block_number);
     let flags = ExecutionFlags {
         only_query: false,
         charge_fee,
@@ -351,7 +362,7 @@ fn show_execution_data(
         } else {
             Path::new("state_dumps/native")
         };
-        let root = root.join(format!("block{}", reader.reader.block_number));
+        let root = root.join(format!("block{}", block_number));
 
         std::fs::create_dir_all(&root).ok();
 

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -319,8 +319,8 @@ fn build_cached_state(network: &str, block_number: u64) -> CachedState<RpcCached
 fn build_reader(network: &str, block_number: u64) -> RpcCachedStateReader {
     let block_number = BlockNumber(block_number);
     let rpc_chain = parse_network(network);
-    let rpc_reader = RpcCachedStateReader::new(RpcStateReader::new(rpc_chain, block_number));
-    return rpc_reader;
+
+    RpcCachedStateReader::new(RpcStateReader::new(rpc_chain, block_number))
 }
 
 fn show_execution_data(

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -330,12 +330,16 @@ fn show_execution_data(
     block_number: u64,
     charge_fee: bool,
 ) {
-    let _transaction_execution_span =
-        info_span!("transaction", hash = tx_hash_str, chain_str).entered();
+    let _transaction_execution_span = info_span!(
+        "transaction",
+        hash = tx_hash_str,
+        chain = chain_str,
+        block = block_number
+    )
+    .entered();
     info!("starting execution");
 
     let tx_hash = TransactionHash(felt!(tx_hash_str.as_str()));
-    let block_number = BlockNumber(block_number);
     let flags = ExecutionFlags {
         only_query: false,
         charge_fee,

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -1,5 +1,4 @@
 use blockifier::state::cached_state::CachedState;
-use blockifier::state::errors::StateError;
 use blockifier::transaction::account_transaction::ExecutionFlags;
 use blockifier::transaction::objects::{RevertError, TransactionExecutionInfo};
 use blockifier::transaction::transactions::ExecutableTransaction;
@@ -106,14 +105,7 @@ fn main() {
             let mut state = build_cached_state(&chain, block_number - 1);
             let reader = build_reader(&chain, block_number);
 
-            show_execution_data(
-                &mut state,
-                &reader,
-                tx_hash,
-                &chain,
-                block_number,
-                charge_fee,
-            );
+            show_execution_data(&mut state, &reader, tx_hash, &chain, charge_fee);
         }
         ReplayExecute::Block {
             block_number,
@@ -135,7 +127,6 @@ fn main() {
                     &reader,
                     tx_hash.0.to_hex_string(),
                     &chain,
-                    block_number,
                     charge_fee,
                 );
             }
@@ -164,7 +155,6 @@ fn main() {
                         &reader,
                         tx_hash.0.to_hex_string(),
                         &chain,
-                        block_number,
                         charge_fee,
                     );
                 }
@@ -328,7 +318,6 @@ fn show_execution_data(
     reader: &RpcCachedStateReader,
     tx_hash_str: String,
     chain_str: &str,
-    block_number: u64,
     charge_fee: bool,
 ) {
     let _transaction_execution_span =
@@ -336,7 +325,6 @@ fn show_execution_data(
     info!("starting execution");
 
     let tx_hash = TransactionHash(felt!(tx_hash_str.as_str()));
-    let block_number = BlockNumber(block_number);
     let flags = ExecutionFlags {
         only_query: false,
         charge_fee,
@@ -363,7 +351,7 @@ fn show_execution_data(
         } else {
             Path::new("state_dumps/native")
         };
-        let root = root.join(format!("block{}", block_number));
+        let root = root.join(format!("block{}", reader.reader.block_number));
 
         std::fs::create_dir_all(&root).ok();
 

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -103,7 +103,9 @@ fn main() {
             charge_fee,
         } => {
             let mut state = build_cached_state(&chain, block_number - 1);
+            state.state.load();
             show_execution_data(&mut state, tx_hash, &chain, block_number, charge_fee);
+            state.state.save();
         }
         ReplayExecute::Block {
             block_number,
@@ -113,6 +115,7 @@ fn main() {
             let _block_span = info_span!("block", number = block_number).entered();
 
             let mut state = build_cached_state(&chain, block_number - 1);
+            state.state.load();
 
             let transaction_hashes = get_transaction_hashes(&chain, block_number)
                 .expect("Unable to fetch the transaction hashes.");
@@ -125,6 +128,8 @@ fn main() {
                     charge_fee,
                 );
             }
+
+            state.state.save();
         }
         ReplayExecute::BlockRange {
             block_start,

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -5,6 +5,7 @@ use blockifier::transaction::objects::{RevertError, TransactionExecutionInfo};
 use blockifier::transaction::transactions::ExecutableTransaction;
 use clap::{Parser, Subcommand};
 
+use rpc_state_reader::cache::RpcCachedStateReader;
 use rpc_state_reader::execution::fetch_transaction;
 use rpc_state_reader::objects::RpcTransactionReceipt;
 use rpc_state_reader::reader::{RpcChain, RpcStateReader};
@@ -295,16 +296,17 @@ fn parse_network(network: &str) -> RpcChain {
     }
 }
 
-fn build_cached_state(network: &str, block_number: u64) -> CachedState<RpcStateReader> {
+fn build_cached_state(network: &str, block_number: u64) -> CachedState<RpcCachedStateReader> {
     let previous_block_number = BlockNumber(block_number);
     let rpc_chain = parse_network(network);
-    let rpc_reader = RpcStateReader::new(rpc_chain, previous_block_number);
+    let rpc_reader =
+        RpcCachedStateReader::new(RpcStateReader::new(rpc_chain, previous_block_number));
 
     CachedState::new(rpc_reader)
 }
 
 fn show_execution_data(
-    state: &mut CachedState<RpcStateReader>,
+    state: &mut CachedState<RpcCachedStateReader>,
     tx_hash_str: String,
     chain_str: &str,
     block_number: u64,

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -7,7 +7,7 @@ use clap::{Parser, Subcommand};
 use rpc_state_reader::cache::RpcCachedStateReader;
 use rpc_state_reader::execution::fetch_transaction_w_state;
 use rpc_state_reader::objects::RpcTransactionReceipt;
-use rpc_state_reader::reader::{RpcChain, RpcStateReader};
+use rpc_state_reader::reader::{RpcChain, RpcStateReader, StateReader};
 use starknet_api::block::BlockNumber;
 use starknet_api::felt;
 use starknet_api::transaction::{TransactionExecutionStatus, TransactionHash};

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -5,7 +5,7 @@ use blockifier::transaction::transactions::ExecutableTransaction;
 use clap::{Parser, Subcommand};
 
 use rpc_state_reader::cache::RpcCachedStateReader;
-use rpc_state_reader::execution::fetch_transaction_w_state;
+use rpc_state_reader::execution::fetch_transaction_with_state;
 use rpc_state_reader::objects::RpcTransactionReceipt;
 use rpc_state_reader::reader::{RpcChain, RpcStateReader, StateReader};
 use starknet_api::block::BlockNumber;
@@ -342,7 +342,7 @@ fn show_execution_data(
         validate: true,
     };
 
-    let (tx, context) = match fetch_transaction_w_state(reader, &tx_hash, flags) {
+    let (tx, context) = match fetch_transaction_with_state(reader, &tx_hash, flags) {
         Ok(x) => x,
         Err(err) => {
             return error!("failed to fetch transaction: {err}");

--- a/rpc-state-reader/Cargo.toml
+++ b/rpc-state-reader/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = { version = "1.0", features = [
   "arbitrary_precision",
   "raw_value",
 ] }
+serde_with = { workspace = true, features = ["macros"] }
 starknet_api = {workspace = true}
 cairo-lang-starknet-classes = "=2.9.2"
 cairo-lang-utils = "=2.9.2"

--- a/rpc-state-reader/src/cache.rs
+++ b/rpc-state-reader/src/cache.rs
@@ -21,6 +21,9 @@ use crate::{
     reader::{compile_contract_class, RpcStateReader},
 };
 
+/// The RpcCache stores the result of RPC calls to memory (and disk)
+///
+/// Each field corresponds to a particular endpoint
 #[serde_as]
 #[derive(Default, Serialize, Deserialize)]
 pub struct RpcCache {

--- a/rpc-state-reader/src/cache.rs
+++ b/rpc-state-reader/src/cache.rs
@@ -41,6 +41,11 @@ pub struct RpcCache {
     pub get_transaction_trace: HashMap<TransactionHash, RpcTransactionTrace>,
 }
 
+/// A wrapper around `RpcStateReader` that caches all rpc calls.
+///
+/// On drop, the cache is saved to disk at `rpc_cache/{block_number}.json`.
+/// It's not safe to use multiple instances of this struct at the same time,
+/// as there is no mechanism for file locking.
 pub struct RpcCachedStateReader {
     pub reader: RpcStateReader,
     state: RefCell<RpcCache>,

--- a/rpc-state-reader/src/cache.rs
+++ b/rpc-state-reader/src/cache.rs
@@ -1,0 +1,31 @@
+use std::collections::HashMap;
+
+use cairo_vm::Felt252;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use starknet::core::types::ContractClass;
+use starknet_api::{
+    core::{ClassHash, ContractAddress, Nonce},
+    state::StorageKey,
+    transaction::{Transaction, TransactionHash},
+};
+
+use crate::objects::{BlockWithTxHahes, RpcTransactionReceipt};
+
+#[serde_as]
+#[derive(Default, Serialize, Deserialize)]
+pub struct RpcCachedState {
+    pub get_block_with_tx_hashes: Option<BlockWithTxHahes>,
+    #[serde_as(as = "Vec<(_, _)>")]
+    pub get_transaction_by_hash: HashMap<TransactionHash, Transaction>,
+    #[serde_as(as = "Vec<(_, _)>")]
+    pub get_contract_class: HashMap<ClassHash, ContractClass>,
+    #[serde_as(as = "Vec<(_, _)>")]
+    pub get_storage_at: HashMap<(ContractAddress, StorageKey), Felt252>,
+    #[serde_as(as = "Vec<(_, _)>")]
+    pub get_nonce_at: HashMap<ContractAddress, Nonce>,
+    #[serde_as(as = "Vec<(_, _)>")]
+    pub get_class_hash_at: HashMap<ContractAddress, ClassHash>,
+    #[serde_as(as = "Vec<(_, _)>")]
+    pub get_transaction_receipt: HashMap<TransactionHash, RpcTransactionReceipt>,
+}

--- a/rpc-state-reader/src/cache.rs
+++ b/rpc-state-reader/src/cache.rs
@@ -15,6 +15,7 @@ use starknet_api::{
     state::StorageKey,
     transaction::{Transaction, TransactionHash},
 };
+use tracing::warn;
 
 use crate::{
     objects::{BlockWithTxHahes, RpcTransactionReceipt, RpcTransactionTrace},
@@ -72,7 +73,10 @@ impl RpcCachedStateReader {
 
             match File::open(path) {
                 Ok(file) => serde_json::from_reader(file).unwrap(),
-                Err(_) => RpcCache::default(),
+                Err(_) => {
+                    warn!("Cache for block {} was not found", reader.block_number);
+                    RpcCache::default()
+                }
             }
         };
 

--- a/rpc-state-reader/src/cache.rs
+++ b/rpc-state-reader/src/cache.rs
@@ -1,5 +1,11 @@
-use std::collections::HashMap;
+use std::{
+    cell::RefCell,
+    collections::{hash_map::Entry, HashMap},
+    fs::{self, File},
+    path::PathBuf,
+};
 
+use blockifier::state::state_api::{StateReader, StateResult};
 use cairo_vm::Felt252;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -10,11 +16,14 @@ use starknet_api::{
     transaction::{Transaction, TransactionHash},
 };
 
-use crate::objects::{BlockWithTxHahes, RpcTransactionReceipt};
+use crate::{
+    objects::{BlockWithTxHahes, RpcTransactionReceipt, RpcTransactionTrace},
+    reader::{compile_contract_class, RpcStateReader},
+};
 
 #[serde_as]
 #[derive(Default, Serialize, Deserialize)]
-pub struct RpcCachedState {
+pub struct RpcCache {
     pub get_block_with_tx_hashes: Option<BlockWithTxHahes>,
     #[serde_as(as = "Vec<(_, _)>")]
     pub get_transaction_by_hash: HashMap<TransactionHash, Transaction>,
@@ -28,4 +37,206 @@ pub struct RpcCachedState {
     pub get_class_hash_at: HashMap<ContractAddress, ClassHash>,
     #[serde_as(as = "Vec<(_, _)>")]
     pub get_transaction_receipt: HashMap<TransactionHash, RpcTransactionReceipt>,
+    #[serde_as(as = "Vec<(_, _)>")]
+    pub get_transaction_trace: HashMap<TransactionHash, RpcTransactionTrace>,
+}
+
+pub struct RpcCachedStateReader {
+    pub reader: RpcStateReader,
+    state: RefCell<RpcCache>,
+}
+
+impl Drop for RpcCachedStateReader {
+    fn drop(&mut self) {
+        let path = PathBuf::from(format!("rpc_cache/{}.json", self.reader.block_number));
+        let parent = path.parent().unwrap();
+        fs::create_dir_all(parent).unwrap();
+        let file = File::create(path).unwrap();
+        serde_json::to_writer_pretty(file, &self.state).unwrap();
+    }
+}
+
+impl RpcCachedStateReader {
+    pub fn new(reader: RpcStateReader) -> Self {
+        let state = {
+            let path = PathBuf::from(format!("rpc_cache/{}.json", reader.block_number));
+
+            match File::open(path) {
+                Ok(file) => serde_json::from_reader(file).unwrap(),
+                Err(_) => RpcCache::default(),
+            }
+        };
+
+        Self {
+            reader,
+            state: RefCell::new(state),
+        }
+    }
+
+    pub fn get_block_with_tx_hashes(&self) -> StateResult<BlockWithTxHahes> {
+        if let Some(block) = &self.state.borrow().get_block_with_tx_hashes {
+            return Ok(block.clone());
+        }
+
+        let result = self.reader.get_block_with_tx_hashes()?;
+
+        self.state.borrow_mut().get_block_with_tx_hashes = Some(result.clone());
+
+        Ok(result)
+    }
+
+    pub fn get_transaction(&self, hash: &TransactionHash) -> StateResult<Transaction> {
+        Ok(
+            match self
+                .state
+                .borrow_mut()
+                .get_transaction_by_hash
+                .entry(hash.clone())
+            {
+                Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
+                Entry::Vacant(vacant_entry) => {
+                    let result = self.reader.get_transaction(hash)?;
+                    vacant_entry.insert(result.clone());
+                    result
+                }
+            },
+        )
+    }
+
+    pub fn get_contract_class(&self, class_hash: &ClassHash) -> StateResult<ContractClass> {
+        Ok(
+            match self
+                .state
+                .borrow_mut()
+                .get_contract_class
+                .entry(class_hash.clone())
+            {
+                Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
+                Entry::Vacant(vacant_entry) => {
+                    let result = self.reader.get_contract_class(class_hash)?;
+                    vacant_entry.insert(result.clone());
+                    result
+                }
+            },
+        )
+    }
+
+    pub fn get_transaction_trace(
+        &self,
+        hash: &TransactionHash,
+    ) -> StateResult<RpcTransactionTrace> {
+        Ok(
+            match self
+                .state
+                .borrow_mut()
+                .get_transaction_trace
+                .entry(hash.clone())
+            {
+                Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
+                Entry::Vacant(vacant_entry) => {
+                    let result = self.reader.get_transaction_trace(hash)?;
+                    vacant_entry.insert(result.clone());
+                    result
+                }
+            },
+        )
+    }
+
+    pub fn get_transaction_receipt(
+        &self,
+        hash: &TransactionHash,
+    ) -> StateResult<RpcTransactionReceipt> {
+        Ok(
+            match self
+                .state
+                .borrow_mut()
+                .get_transaction_receipt
+                .entry(hash.clone())
+            {
+                Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
+                Entry::Vacant(vacant_entry) => {
+                    let result = self.reader.get_transaction_receipt(hash)?;
+                    vacant_entry.insert(result.clone());
+                    result
+                }
+            },
+        )
+    }
+}
+
+impl StateReader for RpcCachedStateReader {
+    fn get_storage_at(
+        &self,
+        contract_address: ContractAddress,
+        key: StorageKey,
+    ) -> StateResult<Felt252> {
+        Ok(
+            match self
+                .state
+                .borrow_mut()
+                .get_storage_at
+                .entry((contract_address.clone(), key.clone()))
+            {
+                Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
+                Entry::Vacant(vacant_entry) => {
+                    let result = self
+                        .reader
+                        .get_storage_at(contract_address.clone(), key.clone())?;
+                    vacant_entry.insert(result.clone());
+                    result
+                }
+            },
+        )
+    }
+
+    fn get_nonce_at(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
+        Ok(
+            match self
+                .state
+                .borrow_mut()
+                .get_nonce_at
+                .entry(contract_address.clone())
+            {
+                Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
+                Entry::Vacant(vacant_entry) => {
+                    let result = self.reader.get_nonce_at(contract_address.clone())?;
+                    vacant_entry.insert(result.clone());
+                    result
+                }
+            },
+        )
+    }
+
+    fn get_class_hash_at(&self, contract_address: ContractAddress) -> StateResult<ClassHash> {
+        Ok(
+            match self
+                .state
+                .borrow_mut()
+                .get_class_hash_at
+                .entry(contract_address.clone())
+            {
+                Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
+                Entry::Vacant(vacant_entry) => {
+                    let result = self.reader.get_class_hash_at(contract_address.clone())?;
+                    vacant_entry.insert(result.clone());
+                    result
+                }
+            },
+        )
+    }
+
+    fn get_compiled_class(
+        &self,
+        class_hash: ClassHash,
+    ) -> StateResult<blockifier::execution::contract_class::RunnableCompiledClass> {
+        let class = self.get_contract_class(&class_hash)?;
+        return Ok(compile_contract_class(class, class_hash));
+    }
+
+    fn get_compiled_class_hash(
+        &self,
+        _class_hash: ClassHash,
+    ) -> StateResult<starknet_api::core::CompiledClassHash> {
+        todo!();
+    }
 }

--- a/rpc-state-reader/src/cache.rs
+++ b/rpc-state-reader/src/cache.rs
@@ -87,12 +87,7 @@ impl RpcCachedStateReader {
 
     pub fn get_transaction(&self, hash: &TransactionHash) -> StateResult<Transaction> {
         Ok(
-            match self
-                .state
-                .borrow_mut()
-                .get_transaction_by_hash
-                .entry(hash.clone())
-            {
+            match self.state.borrow_mut().get_transaction_by_hash.entry(*hash) {
                 Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
                 Entry::Vacant(vacant_entry) => {
                     let result = self.reader.get_transaction(hash)?;
@@ -109,7 +104,7 @@ impl RpcCachedStateReader {
                 .state
                 .borrow_mut()
                 .get_contract_class
-                .entry(class_hash.clone())
+                .entry(*class_hash)
             {
                 Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
                 Entry::Vacant(vacant_entry) => {
@@ -126,12 +121,7 @@ impl RpcCachedStateReader {
         hash: &TransactionHash,
     ) -> StateResult<RpcTransactionTrace> {
         Ok(
-            match self
-                .state
-                .borrow_mut()
-                .get_transaction_trace
-                .entry(hash.clone())
-            {
+            match self.state.borrow_mut().get_transaction_trace.entry(*hash) {
                 Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
                 Entry::Vacant(vacant_entry) => {
                     let result = self.reader.get_transaction_trace(hash)?;
@@ -147,12 +137,7 @@ impl RpcCachedStateReader {
         hash: &TransactionHash,
     ) -> StateResult<RpcTransactionReceipt> {
         Ok(
-            match self
-                .state
-                .borrow_mut()
-                .get_transaction_receipt
-                .entry(hash.clone())
-            {
+            match self.state.borrow_mut().get_transaction_receipt.entry(*hash) {
                 Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
                 Entry::Vacant(vacant_entry) => {
                     let result = self.reader.get_transaction_receipt(hash)?;
@@ -175,14 +160,12 @@ impl StateReader for RpcCachedStateReader {
                 .state
                 .borrow_mut()
                 .get_storage_at
-                .entry((contract_address.clone(), key.clone()))
+                .entry((contract_address, key))
             {
-                Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
+                Entry::Occupied(occupied_entry) => *occupied_entry.get(),
                 Entry::Vacant(vacant_entry) => {
-                    let result = self
-                        .reader
-                        .get_storage_at(contract_address.clone(), key.clone())?;
-                    vacant_entry.insert(result.clone());
+                    let result = self.reader.get_storage_at(contract_address, key)?;
+                    vacant_entry.insert(result);
                     result
                 }
             },
@@ -191,16 +174,11 @@ impl StateReader for RpcCachedStateReader {
 
     fn get_nonce_at(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
         Ok(
-            match self
-                .state
-                .borrow_mut()
-                .get_nonce_at
-                .entry(contract_address.clone())
-            {
-                Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
+            match self.state.borrow_mut().get_nonce_at.entry(contract_address) {
+                Entry::Occupied(occupied_entry) => *occupied_entry.get(),
                 Entry::Vacant(vacant_entry) => {
-                    let result = self.reader.get_nonce_at(contract_address.clone())?;
-                    vacant_entry.insert(result.clone());
+                    let result = self.reader.get_nonce_at(contract_address)?;
+                    vacant_entry.insert(result);
                     result
                 }
             },
@@ -213,12 +191,12 @@ impl StateReader for RpcCachedStateReader {
                 .state
                 .borrow_mut()
                 .get_class_hash_at
-                .entry(contract_address.clone())
+                .entry(contract_address)
             {
-                Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
+                Entry::Occupied(occupied_entry) => *occupied_entry.get(),
                 Entry::Vacant(vacant_entry) => {
-                    let result = self.reader.get_class_hash_at(contract_address.clone())?;
-                    vacant_entry.insert(result.clone());
+                    let result = self.reader.get_class_hash_at(contract_address)?;
+                    vacant_entry.insert(result);
                     result
                 }
             },
@@ -230,7 +208,7 @@ impl StateReader for RpcCachedStateReader {
         class_hash: ClassHash,
     ) -> StateResult<blockifier::execution::contract_class::RunnableCompiledClass> {
         let class = self.get_contract_class(&class_hash)?;
-        return Ok(compile_contract_class(class, class_hash));
+        Ok(compile_contract_class(class, class_hash))
     }
 
     fn get_compiled_class_hash(

--- a/rpc-state-reader/src/cache.rs
+++ b/rpc-state-reader/src/cache.rs
@@ -28,6 +28,7 @@ use crate::{
 #[derive(Default, Serialize, Deserialize)]
 pub struct RpcCache {
     pub get_block_with_tx_hashes: Option<BlockWithTxHahes>,
+    // we need to serialize it as a vector to allow non string key types
     #[serde_as(as = "Vec<(_, _)>")]
     pub get_transaction_by_hash: HashMap<TransactionHash, Transaction>,
     #[serde_as(as = "Vec<(_, _)>")]

--- a/rpc-state-reader/src/cache.rs
+++ b/rpc-state-reader/src/cache.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use starknet::core::types::ContractClass;
 use starknet_api::{
-    core::{ClassHash, ContractAddress, Nonce},
+    core::{ChainId, ClassHash, ContractAddress, Nonce},
     state::StorageKey,
     transaction::{Transaction, TransactionHash},
 };
@@ -149,6 +149,10 @@ impl StateReader for RpcCachedStateReader {
                 }
             },
         )
+    }
+
+    fn get_chain_id(&self) -> ChainId {
+        self.reader.get_chain_id()
     }
 }
 

--- a/rpc-state-reader/src/execution.rs
+++ b/rpc-state-reader/src/execution.rs
@@ -116,7 +116,7 @@ pub fn execute_transaction(
 /// Due to limitations in the CachedState, we need to fetch this information
 /// separately, and can't be done with only the CachedState
 ///
-/// It doesn't use the rpc cache. See `fetch_transaction_w_state` to specify a custom reader.:w
+/// It doesn't use the rpc cache. See `fetch_transaction_w_state` to specify a custom reader.
 pub fn fetch_transaction(
     hash: &TransactionHash,
     block_number: BlockNumber,

--- a/rpc-state-reader/src/execution.rs
+++ b/rpc-state-reader/src/execution.rs
@@ -108,10 +108,13 @@ pub fn fetch_transaction(
     chain: RpcChain,
     flags: ExecutionFlags,
 ) -> anyhow::Result<(BlockiTransaction, BlockContext)> {
-    let reader = RpcStateReader::new(chain, block_number);
+    let mut reader = RpcStateReader::new(chain, block_number);
+    reader.load();
+
     let transaction = fetch_blockifier_transaction(&reader, flags, *hash)?;
     let context = fetch_block_context(&reader)?;
 
+    reader.save();
     Ok((transaction, context))
 }
 

--- a/rpc-state-reader/src/execution.rs
+++ b/rpc-state-reader/src/execution.rs
@@ -1,7 +1,7 @@
 use crate::{
     cache::RpcCachedStateReader,
     objects::BlockHeader,
-    reader::{RpcChain, RpcStateReader},
+    reader::{RpcChain, RpcStateReader, StateReader},
 };
 use anyhow::Context;
 use blockifier::{

--- a/rpc-state-reader/src/execution.rs
+++ b/rpc-state-reader/src/execution.rs
@@ -133,7 +133,7 @@ pub fn fetch_transaction(
 /// Fetches all information needed to execute a given transaction
 ///
 /// Like `fetch_transaction`, but with a custom reader.
-pub fn fetch_transaction_w_state(
+pub fn fetch_transaction_with_state(
     reader: &impl StateReader,
     hash: &TransactionHash,
     flags: ExecutionFlags,

--- a/rpc-state-reader/src/execution.rs
+++ b/rpc-state-reader/src/execution.rs
@@ -142,6 +142,7 @@ pub fn fetch_transaction_w_state(
     Ok((transaction, context))
 }
 
+/// Derives `BlockInfo` from the `BlockHeader`
 pub fn get_block_info(header: BlockHeader) -> BlockInfo {
     fn parse_gas_price(price: GasPrice) -> NonzeroGasPrice {
         NonzeroGasPrice::new(price).unwrap_or(NonzeroGasPrice::MIN)
@@ -163,6 +164,7 @@ pub fn get_block_info(header: BlockHeader) -> BlockInfo {
     }
 }
 
+/// Derives `ClassInfo` from the `ContractClass`
 pub fn get_class_info(class: ContractClass) -> anyhow::Result<ClassInfo> {
     match class {
         ContractClass::Sierra(sierra) => {

--- a/rpc-state-reader/src/execution.rs
+++ b/rpc-state-reader/src/execution.rs
@@ -128,6 +128,20 @@ pub fn fetch_transaction(
     Ok((transaction, context))
 }
 
+/// Fetches all information needed to execute a given transaction
+///
+/// Like `fetch_transaction`, but with a custom reader
+pub fn fetch_transaction_w_state(
+    reader: &RpcCachedStateReader,
+    hash: &TransactionHash,
+    flags: ExecutionFlags,
+) -> anyhow::Result<(BlockiTransaction, BlockContext)> {
+    let transaction = fetch_blockifier_transaction(&reader, flags, *hash)?;
+    let context = fetch_block_context(&reader)?;
+
+    Ok((transaction, context))
+}
+
 pub fn get_block_info(header: BlockHeader) -> BlockInfo {
     fn parse_gas_price(price: GasPrice) -> NonzeroGasPrice {
         NonzeroGasPrice::new(price).unwrap_or(NonzeroGasPrice::MIN)

--- a/rpc-state-reader/src/execution.rs
+++ b/rpc-state-reader/src/execution.rs
@@ -214,7 +214,7 @@ mod tests {
     };
     use pretty_assertions_sorted::assert_eq_sorted;
     use starknet_api::{
-        block::BlockNumber,
+        block::{BlockNumber, FeeType},
         class_hash,
         execution_resources::{GasAmount, GasVector},
         felt,
@@ -3233,5 +3233,18 @@ mod tests {
                 revert_reason: value.execution.failed.then_some("Default String".into()),
             }
         }
+    }
+
+    #[test]
+    fn test_get_block_info() {
+        let reader = RpcStateReader::new(RpcChain::MainNet, BlockNumber(169928));
+
+        let block = reader.get_block_with_tx_hashes().unwrap();
+        let info = get_block_info(block.header);
+
+        assert_eq!(
+            info.gas_prices.l1_gas_price(&FeeType::Eth).get().0,
+            22804578690
+        );
     }
 }

--- a/rpc-state-reader/src/execution.rs
+++ b/rpc-state-reader/src/execution.rs
@@ -120,11 +120,10 @@ pub fn fetch_transaction(
     chain: RpcChain,
     flags: ExecutionFlags,
 ) -> anyhow::Result<(BlockiTransaction, BlockContext)> {
-    let reader = RpcStateReader::new(chain, block_number);
-    let cached_reader = RpcCachedStateReader::new(reader);
+    let reader = RpcCachedStateReader::new(RpcStateReader::new(chain, block_number));
 
-    let transaction = fetch_blockifier_transaction(&cached_reader, flags, *hash)?;
-    let context = fetch_block_context(&cached_reader)?;
+    let transaction = fetch_blockifier_transaction(&reader, flags, *hash)?;
+    let context = fetch_block_context(&reader)?;
 
     Ok((transaction, context))
 }

--- a/rpc-state-reader/src/execution.rs
+++ b/rpc-state-reader/src/execution.rs
@@ -136,8 +136,8 @@ pub fn fetch_transaction_w_state(
     hash: &TransactionHash,
     flags: ExecutionFlags,
 ) -> anyhow::Result<(BlockiTransaction, BlockContext)> {
-    let transaction = fetch_blockifier_transaction(&reader, flags, *hash)?;
-    let context = fetch_block_context(&reader)?;
+    let transaction = fetch_blockifier_transaction(reader, flags, *hash)?;
+    let context = fetch_block_context(reader)?;
 
     Ok((transaction, context))
 }

--- a/rpc-state-reader/src/execution.rs
+++ b/rpc-state-reader/src/execution.rs
@@ -91,6 +91,8 @@ pub fn fetch_blockifier_transaction(
 /// Internally, it creates its own blank state, so it may fail when executing
 /// a transaction in the middle of a block, if it depends on a previous transaction
 /// of the same block.
+///
+/// It doesn't use the rpc cache.
 pub fn execute_transaction(
     hash: &TransactionHash,
     block_number: BlockNumber,
@@ -113,6 +115,8 @@ pub fn execute_transaction(
 ///
 /// Due to limitations in the CachedState, we need to fetch this information
 /// separately, and can't be done with only the CachedState
+///
+/// It doesn't use the rpc cache. See `fetch_transaction_w_state` to specify a custom reader.:w
 pub fn fetch_transaction(
     hash: &TransactionHash,
     block_number: BlockNumber,

--- a/rpc-state-reader/src/lib.rs
+++ b/rpc-state-reader/src/lib.rs
@@ -6,7 +6,7 @@ pub mod utils;
 
 #[cfg(test)]
 mod tests {
-    use blockifier::state::state_api::StateReader;
+    use blockifier::state::state_api::StateReader as _;
     use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
     use starknet_api::{
         block::BlockNumber,

--- a/rpc-state-reader/src/lib.rs
+++ b/rpc-state-reader/src/lib.rs
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn test_get_nonce_at() {
-        let rpc_state = RpcStateReader::new(RpcChain::TestNet, BlockNumber(700000));
+        let rpc_state = RpcStateReader::new(RpcChain::TestNet, BlockNumber(400000));
         // Contract deployed by xqft which will not be used again, so nonce changes will not break
         // this test.
         let address =

--- a/rpc-state-reader/src/lib.rs
+++ b/rpc-state-reader/src/lib.rs
@@ -9,6 +9,7 @@ mod tests {
     use blockifier::state::state_api::StateReader;
     use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
     use starknet_api::{
+        block::BlockNumber,
         class_hash,
         core::{ContractAddress, Nonce},
         felt,
@@ -31,7 +32,7 @@ mod tests {
 
     #[test]
     fn test_get_contract_class_cairo1() {
-        let rpc_state = RpcStateReader::new_latest(RpcChain::MainNet);
+        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
 
         let class_hash =
             class_hash!("0298e56befa6d1446b86ed5b900a9ba51fd2faa683cd6f50e8f833c0fb847216");
@@ -44,7 +45,7 @@ mod tests {
 
     #[test]
     fn test_get_contract_class_cairo0() {
-        let rpc_state = RpcStateReader::new_latest(RpcChain::MainNet);
+        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
 
         let class_hash =
             class_hash!("025ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918");
@@ -53,7 +54,7 @@ mod tests {
 
     #[test]
     fn test_get_class_hash_at() {
-        let rpc_state = RpcStateReader::new_latest(RpcChain::MainNet);
+        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
         let address =
             contract_address!("00b081f7ba1efc6fe98770b09a827ae373ef2baa6116b3d2a0bf5154136573a9");
 
@@ -65,7 +66,7 @@ mod tests {
 
     #[test]
     fn test_get_nonce_at() {
-        let rpc_state = RpcStateReader::new_latest(RpcChain::TestNet);
+        let rpc_state = RpcStateReader::new(RpcChain::TestNet, BlockNumber(700000));
         // Contract deployed by xqft which will not be used again, so nonce changes will not break
         // this test.
         let address =
@@ -78,7 +79,7 @@ mod tests {
 
     #[test]
     fn test_get_storage_at() {
-        let rpc_state = RpcStateReader::new_latest(RpcChain::MainNet);
+        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
         let address =
             contract_address!("00b081f7ba1efc6fe98770b09a827ae373ef2baa6116b3d2a0bf5154136573a9");
         let key = StorageKey(patricia_key!(0u128));
@@ -91,7 +92,7 @@ mod tests {
 
     #[test]
     fn test_get_transaction() {
-        let rpc_state = RpcStateReader::new_latest(RpcChain::MainNet);
+        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
         let tx_hash = TransactionHash(
             StarkHash::from_hex("06da92cfbdceac5e5e94a1f40772d6c79d34f011815606742658559ec77b6955")
                 .unwrap(),
@@ -102,7 +103,7 @@ mod tests {
 
     #[test]
     fn test_get_block_info() {
-        let rpc_state = RpcStateReader::new_latest(RpcChain::MainNet);
+        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
 
         assert!(rpc_state.get_block_info().is_ok());
     }
@@ -111,7 +112,7 @@ mod tests {
     // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction_trace?transactionHash=0x035673e42bd485ae699c538d8502f730d1137545b22a64c094ecdaf86c59e592
     #[test]
     fn test_get_transaction_trace() {
-        let rpc_state = RpcStateReader::new_latest(RpcChain::MainNet);
+        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
 
         let tx_hash = TransactionHash(
             StarkHash::from_hex(
@@ -249,7 +250,7 @@ mod tests {
 
     #[test]
     fn test_get_transaction_receipt() {
-        let rpc_state = RpcStateReader::new_latest(RpcChain::MainNet);
+        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
         let tx_hash = TransactionHash(
             StarkHash::from_hex("06da92cfbdceac5e5e94a1f40772d6c79d34f011815606742658559ec77b6955")
                 .unwrap(),

--- a/rpc-state-reader/src/lib.rs
+++ b/rpc-state-reader/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod execution;
 pub mod objects;
 pub mod reader;

--- a/rpc-state-reader/src/lib.rs
+++ b/rpc-state-reader/src/lib.rs
@@ -101,13 +101,6 @@ mod tests {
         rpc_state.get_transaction(&tx_hash).unwrap();
     }
 
-    #[test]
-    fn test_get_block_info() {
-        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
-
-        assert!(rpc_state.get_block_info().is_ok());
-    }
-
     // Tested with the following query to the Feeder Gateway API:
     // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction_trace?transactionHash=0x035673e42bd485ae699c538d8502f730d1137545b22a64c094ecdaf86c59e592
     #[test]

--- a/rpc-state-reader/src/objects.rs
+++ b/rpc-state-reader/src/objects.rs
@@ -12,7 +12,7 @@ use starknet_api::{
     },
 };
 
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
 pub struct RpcTransactionTrace {
     pub validate_invocation: Option<RpcCallInfo>,
     #[serde(
@@ -24,7 +24,7 @@ pub struct RpcTransactionTrace {
     pub fee_transfer_invocation: Option<RpcCallInfo>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Default, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Default, Deserialize, Serialize)]
 pub struct RpcCallInfo {
     pub result: Option<Vec<StarkHash>>,
     pub calldata: Option<Vec<StarkHash>>,

--- a/rpc-state-reader/src/objects.rs
+++ b/rpc-state-reader/src/objects.rs
@@ -4,7 +4,7 @@
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use serde::{Deserialize, Serialize};
 use starknet_api::{
-    block::{BlockHash, BlockNumber, BlockStatus, BlockTimestamp},
+    block::{BlockHash, BlockNumber, BlockStatus, BlockTimestamp, GasPrice},
     core::{ContractAddress, GlobalRoot},
     data_availability::L1DataAvailabilityMode,
     hash::StarkHash,
@@ -12,7 +12,6 @@ use starknet_api::{
         fields::Fee, Event, MessageToL1, Transaction, TransactionExecutionStatus, TransactionHash,
     },
 };
-use starknet_gateway::rpc_objects::ResourcePrice;
 
 #[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 pub struct RpcTransactionTrace {
@@ -35,7 +34,7 @@ pub struct RpcCallInfo {
     pub revert_reason: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RpcTransactionReceipt {
     pub transaction_hash: TransactionHash,
     pub block_hash: StarkHash,
@@ -51,7 +50,7 @@ pub struct RpcTransactionReceipt {
     pub execution_resources: ExecutionResources,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FeePayment {
     pub amount: Fee,
     pub unit: String,
@@ -60,7 +59,7 @@ pub struct FeePayment {
 // The following structures are taken from https://github.com/starkware-libs/sequencer,
 // but modified to suit our particular needs.
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BlockHeader {
     pub block_hash: BlockHash,
     pub parent_hash: BlockHash,
@@ -74,7 +73,7 @@ pub struct BlockHeader {
     pub starknet_version: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BlockWithTxHahes {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<BlockStatus>,
@@ -98,6 +97,12 @@ pub struct TransactionWithHash {
     #[serde(flatten)]
     #[serde(deserialize_with = "deser::deserialize_transaction")]
     pub transaction: Transaction,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct ResourcePrice {
+    pub price_in_wei: GasPrice,
+    pub price_in_fri: GasPrice,
 }
 
 /// Some types require their own deserializer, as their ir shape is slightly different

--- a/rpc-state-reader/src/reader.rs
+++ b/rpc-state-reader/src/reader.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::RefCell,
     env, fmt,
     fs::File,
     path::PathBuf,
@@ -46,10 +47,7 @@ use ureq::json;
 
 use crate::{
     cache::RpcCachedState,
-    objects::{
-        self, BlockHeader, BlockWithTxHahes, BlockWithTxs, RpcTransactionReceipt,
-        RpcTransactionTrace,
-    },
+    objects::{self, BlockHeader, BlockWithTxHahes, RpcTransactionReceipt, RpcTransactionTrace},
     utils,
 };
 
@@ -90,7 +88,7 @@ const RETRY_SLEEP_MS: u64 = 10000;
 
 pub struct RpcStateReader {
     chain: RpcChain,
-    state: RpcCachedState,
+    state: RefCell<RpcCachedState>,
     block_number: BlockNumber,
     inner: GatewayRpcStateReader,
 }
@@ -102,7 +100,7 @@ impl RpcStateReader {
         Self {
             inner: GatewayRpcStateReader::from_number(&config, block_number),
             chain,
-            state: RpcCachedState::default(),
+            state: Default::default(),
             block_number,
         }
     }

--- a/rpc-state-reader/src/reader.rs
+++ b/rpc-state-reader/src/reader.rs
@@ -152,7 +152,7 @@ impl RpcStateReader {
         self.state
             .borrow_mut()
             .get_contract_class
-            .insert(class_hash.clone(), result.clone());
+            .insert(*class_hash, result.clone());
 
         Ok(result)
     }
@@ -192,7 +192,7 @@ impl RpcStateReader {
         self.state
             .borrow_mut()
             .get_transaction_by_hash
-            .insert(hash.clone(), result.clone());
+            .insert(*hash, result.clone());
 
         Ok(result)
     }
@@ -270,7 +270,7 @@ impl RpcStateReader {
             .state
             .borrow_mut()
             .get_transaction_receipt
-            .insert(hash.clone(), result.clone());
+            .insert(*hash, result.clone());
 
         Ok(result)
     }
@@ -334,7 +334,7 @@ impl StateReader for RpcStateReader {
             .get_storage_at
             .get(&(contract_address, key))
         {
-            return Ok(result.clone());
+            return Ok(*result);
         }
 
         let get_storage_at_params = GetStorageAtParams {
@@ -366,7 +366,7 @@ impl StateReader for RpcStateReader {
         contract_address: ContractAddress,
     ) -> StateResult<starknet_api::core::Nonce> {
         if let Some(result) = self.state.borrow().get_nonce_at.get(&contract_address) {
-            return Ok(result.clone());
+            return Ok(*result);
         }
 
         let get_nonce_params = GetNonceParams {
@@ -393,7 +393,7 @@ impl StateReader for RpcStateReader {
 
     fn get_class_hash_at(&self, contract_address: ContractAddress) -> StateResult<ClassHash> {
         if let Some(result) = self.state.borrow().get_class_hash_at.get(&contract_address) {
-            return Ok(result.clone());
+            return Ok(*result);
         }
 
         let get_class_hash_at_params = GetClassHashAtParams {

--- a/rpc-state-reader/src/reader.rs
+++ b/rpc-state-reader/src/reader.rs
@@ -47,7 +47,7 @@ use ureq::json;
 
 use crate::{
     cache::RpcCachedState,
-    objects::{self, BlockHeader, BlockWithTxHahes, RpcTransactionReceipt, RpcTransactionTrace},
+    objects::{self, BlockWithTxHahes, RpcTransactionReceipt, RpcTransactionTrace},
     utils,
 };
 

--- a/rpc-state-reader/src/reader.rs
+++ b/rpc-state-reader/src/reader.rs
@@ -200,17 +200,6 @@ impl RpcStateReader {
         .map_err(serde_err_to_state_err)
     }
 
-    pub fn get_block_with_txs(&self) -> StateResult<BlockWithTxs> {
-        let params = GetBlockWithTxHashesParams {
-            block_id: self.inner.block_id,
-        };
-
-        serde_json::from_value(
-            self.send_rpc_request_with_retry("starknet_getBlockWithTxs", params)?,
-        )
-        .map_err(serde_err_to_state_err)
-    }
-
     pub fn get_transaction_receipt(
         &self,
         hash: &TransactionHash,

--- a/rpc-state-reader/src/reader.rs
+++ b/rpc-state-reader/src/reader.rs
@@ -386,18 +386,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_block_info() {
-        let reader = RpcStateReader::new(RpcChain::MainNet, BlockNumber(169928));
-
-        let block = reader.get_block_info().unwrap();
-
-        assert_eq!(
-            block.gas_prices.l1_gas_price(&FeeType::Eth).get().0,
-            22804578690
-        );
-    }
-
-    #[test]
     fn test_get_block_with_tx_hashes() {
         let reader = RpcStateReader::new(RpcChain::MainNet, BlockNumber(397709));
 

--- a/rpc-state-reader/src/reader.rs
+++ b/rpc-state-reader/src/reader.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use blockifier::{
-    blockifier::block::validated_gas_prices,
     execution::{
         contract_class::{
             CompiledClassV0, CompiledClassV0Inner, CompiledClassV1, RunnableCompiledClass,
@@ -22,7 +21,7 @@ use serde::Serialize;
 use serde_json::Value;
 use starknet::core::types::ContractClass as SNContractClass;
 use starknet_api::{
-    block::{BlockInfo, BlockNumber, GasPrice, NonzeroGasPrice},
+    block::BlockNumber,
     core::{ChainId, ClassHash, CompiledClassHash, ContractAddress, Nonce},
     state::StorageKey,
     transaction::{Transaction, TransactionHash},
@@ -39,10 +38,7 @@ use tracing::{info, info_span};
 use ureq::json;
 
 use crate::{
-    objects::{
-        self, BlockHeader, BlockWithTxHahes, BlockWithTxs, RpcTransactionReceipt,
-        RpcTransactionTrace,
-    },
+    objects::{self, BlockWithTxHahes, BlockWithTxs, RpcTransactionReceipt, RpcTransactionTrace},
     utils,
 };
 
@@ -381,7 +377,6 @@ fn bytecode_size(data: &[BigUintAsHex]) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use starknet_api::block::FeeType;
 
     use super::*;
 

--- a/rpc-state-reader/src/reader.rs
+++ b/rpc-state-reader/src/reader.rs
@@ -80,6 +80,7 @@ pub trait StateReader: BlockifierStateReader {
     fn get_transaction_trace(&self, hash: &TransactionHash) -> StateResult<RpcTransactionTrace>;
     fn get_transaction_receipt(&self, hash: &TransactionHash)
         -> StateResult<RpcTransactionReceipt>;
+    fn get_chain_id(&self) -> ChainId;
 }
 
 // The following structure is heavily inspired by the underlying starkware-libs/sequencer implementation.
@@ -115,10 +116,6 @@ impl RpcStateReader {
         } else {
             result
         }
-    }
-
-    pub fn get_chain_id(&self) -> ChainId {
-        self.chain.into()
     }
 }
 
@@ -171,6 +168,10 @@ impl StateReader for RpcStateReader {
             self.send_rpc_request_with_retry("starknet_getTransactionReceipt", params)?,
         )
         .map_err(serde_err_to_state_err)
+    }
+
+    fn get_chain_id(&self) -> ChainId {
+        self.chain.into()
     }
 }
 

--- a/rpc-state-reader/src/reader.rs
+++ b/rpc-state-reader/src/reader.rs
@@ -43,6 +43,7 @@ use tracing::{info, info_span};
 use ureq::json;
 
 use crate::{
+    cache::RpcCachedState,
     objects::{
         self, BlockHeader, BlockWithTxHahes, BlockWithTxs, RpcTransactionReceipt,
         RpcTransactionTrace,
@@ -87,6 +88,7 @@ const RETRY_SLEEP_MS: u64 = 10000;
 
 pub struct RpcStateReader {
     chain: RpcChain,
+    state: RpcCachedState,
     inner: GatewayRpcStateReader,
 }
 
@@ -97,6 +99,7 @@ impl RpcStateReader {
         Self {
             inner: GatewayRpcStateReader::from_number(&config, block_number),
             chain,
+            state: RpcCachedState::default(),
         }
     }
 
@@ -106,6 +109,7 @@ impl RpcStateReader {
         Self {
             inner: GatewayRpcStateReader::from_latest(&config),
             chain,
+            state: RpcCachedState::default(),
         }
     }
 

--- a/rpc-state-reader/src/reader.rs
+++ b/rpc-state-reader/src/reader.rs
@@ -1,15 +1,12 @@
 use std::{
     cell::RefCell,
     env, fmt,
-    fs::{self, File},
-    path::PathBuf,
     sync::Arc,
     thread,
     time::{Duration, Instant},
 };
 
 use blockifier::{
-    blockifier::block::validated_gas_prices,
     execution::{
         contract_class::{
             CompiledClassV0, CompiledClassV0Inner, CompiledClassV1, RunnableCompiledClass,
@@ -28,7 +25,7 @@ use serde::Serialize;
 use serde_json::Value;
 use starknet::core::types::ContractClass as SNContractClass;
 use starknet_api::{
-    block::{BlockInfo, BlockNumber, GasPrice, NonzeroGasPrice},
+    block::BlockNumber,
     contract_class::{ClassInfo, SierraVersion},
     core::{ChainId, ClassHash, CompiledClassHash, ContractAddress, Nonce},
     state::StorageKey,
@@ -46,7 +43,7 @@ use tracing::{info, info_span};
 use ureq::json;
 
 use crate::{
-    cache::RpcCachedState,
+    cache::RpcCache,
     objects::{self, BlockWithTxHahes, RpcTransactionReceipt, RpcTransactionTrace},
     utils,
 };
@@ -88,8 +85,8 @@ const RETRY_SLEEP_MS: u64 = 10000;
 
 pub struct RpcStateReader {
     chain: RpcChain,
-    state: RefCell<RpcCachedState>,
-    block_number: BlockNumber,
+    state: RefCell<RpcCache>,
+    pub block_number: BlockNumber,
     inner: GatewayRpcStateReader,
 }
 
@@ -103,22 +100,6 @@ impl RpcStateReader {
             state: Default::default(),
             block_number,
         }
-    }
-
-    pub fn load(&mut self) {
-        let path = PathBuf::from(format!("rpc_cache/{}.json", self.block_number));
-        let Ok(file) = File::open(path) else { return };
-        self.state = serde_json::from_reader(file).unwrap();
-    }
-
-    pub fn save(&self) {
-        let path = PathBuf::from(format!("rpc_cache/{}.json", self.block_number));
-        {
-            let parent = path.parent().unwrap();
-            fs::create_dir_all(parent).unwrap();
-        }
-        let file = File::create(path).unwrap();
-        serde_json::to_writer_pretty(file, &self.state).unwrap();
     }
 
     pub fn send_rpc_request_with_retry(
@@ -195,31 +176,6 @@ impl RpcStateReader {
             .insert(*hash, result.clone());
 
         Ok(result)
-    }
-
-    pub fn get_block_info(&self) -> StateResult<BlockInfo> {
-        // This function is inspired by sequencer's RpcStateReader::get_block_info
-
-        fn parse_gas_price(price: GasPrice) -> NonzeroGasPrice {
-            NonzeroGasPrice::new(price).unwrap_or(NonzeroGasPrice::MIN)
-        }
-
-        let header = self.get_block_with_tx_hashes()?.header;
-
-        Ok(BlockInfo {
-            block_number: header.block_number,
-            sequencer_address: header.sequencer_address,
-            block_timestamp: header.timestamp,
-            gas_prices: validated_gas_prices(
-                parse_gas_price(header.l1_gas_price.price_in_wei),
-                parse_gas_price(header.l1_gas_price.price_in_fri),
-                parse_gas_price(header.l1_data_gas_price.price_in_wei),
-                parse_gas_price(header.l1_data_gas_price.price_in_fri),
-                NonzeroGasPrice::MIN,
-                NonzeroGasPrice::MIN,
-            ),
-            use_kzg_da: true,
-        })
     }
 
     pub fn get_block_with_tx_hashes(&self) -> StateResult<BlockWithTxHahes> {
@@ -422,18 +378,23 @@ impl StateReader for RpcStateReader {
     }
 
     fn get_compiled_class(&self, class_hash: ClassHash) -> StateResult<RunnableCompiledClass> {
-        Ok(match self.get_contract_class(&class_hash)? {
-            SNContractClass::Legacy(compressed_legacy_cc) => {
-                compile_legacy_cc(compressed_legacy_cc)
-            }
-            SNContractClass::Sierra(flattened_sierra_cc) => {
-                compile_sierra_cc(flattened_sierra_cc, class_hash)
-            }
-        })
+        Ok(compile_contract_class(
+            self.get_contract_class(&class_hash)?,
+            class_hash,
+        ))
     }
 
     fn get_compiled_class_hash(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
         self.inner.get_compiled_class_hash(class_hash)
+    }
+}
+
+pub fn compile_contract_class(class: SNContractClass, hash: ClassHash) -> RunnableCompiledClass {
+    match class {
+        SNContractClass::Legacy(compressed_legacy_cc) => compile_legacy_cc(compressed_legacy_cc),
+        SNContractClass::Sierra(flattened_sierra_cc) => {
+            compile_sierra_cc(flattened_sierra_cc, hash)
+        }
     }
 }
 
@@ -537,21 +498,7 @@ fn bytecode_size(data: &[BigUintAsHex]) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use starknet_api::block::FeeType;
-
     use super::*;
-
-    #[test]
-    fn test_get_block_info() {
-        let reader = RpcStateReader::new(RpcChain::MainNet, BlockNumber(169928));
-
-        let block = reader.get_block_info().unwrap();
-
-        assert_eq!(
-            block.gas_prices.l1_gas_price(&FeeType::Eth).get().0,
-            22804578690
-        );
-    }
 
     #[test]
     fn test_get_block_with_tx_hashes() {

--- a/rpc-state-reader/src/reader.rs
+++ b/rpc-state-reader/src/reader.rs
@@ -103,15 +103,6 @@ impl RpcStateReader {
         }
     }
 
-    pub fn new_latest(chain: RpcChain) -> Self {
-        let config = build_config(chain);
-
-        Self {
-            inner: GatewayRpcStateReader::from_latest(&config),
-            chain,
-            state: RpcCachedState::default(),
-        }
-    }
 
     pub fn send_rpc_request_with_retry(
         &self,


### PR DESCRIPTION
Adds cache to RPC calls.

Depends on #107

## Overview

- Defines a new structure `RpcCachedStateReader` that wraps around `RpcStateReader` and caches each RPC call made. On drop, the whole cache is stored on disk.
- Also defines a new trait `StateReader` that both the cache and non-cache readers implement. Some `RpcStateReader` methods were moved to this trait.
- By default, the execution functions don't use the cache. I added a new function `fetch_transaction_with_state` that receives a custom reader, and thus can use `RpcCachedStateReader`.
- The cached data is stored in the `rpc_cache` directory, with a single file for each block.

Note: Only a single instance of replay should run at a time, to avoid race conditions.

## Other Changes

- In addition to RPC calls, the `RpcStateReader` had additional logic for deriving certain structures from other ones. For example, `BlockInfo` could be derived from `BlockWithTxHashes`. I moved this logic to helper functions that could be used where needed.
- The state reader had a constructor `new_latest` that was not being used. I removed it as it made implementing the cache more difficult.
- The field `execution_resources` on `RpcTransactionReceipt` only had information relevant to the VM. I removed it as it was not used, and made serialization more difficult.

## Measurements

### Block 700000 - Server

**Time without cache:**
```bash
$ time ...
real    2m29.234s
user    1m45.287s
sys     0m4.988s
```

**Time with cache:**
```bash
$ time ...
real    1m52.613s
user    1m39.804s
sys     0m12.808s
```

**Disk usage**: 20MB

### Block 700000 - Mac

**Time without cache:**
```bash
$ time ...
Executed in  679.47 secs    fish           external
   usr time   91.62 secs    0.18 millis   91.62 secs
   sys time    5.66 secs    1.07 millis    5.66 secs
```

**Time with cache:**
```bash
$ time ...
Executed in  101.59 secs    fish           external
   usr time   88.94 secs   51.00 micros   88.94 secs
   sys time   11.91 secs  580.00 micros   11.91 secs
```

**Disk usage**: 20MB

