### PR TITLE
Add locking to avoid race conditions in cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6183,6 +6183,7 @@ dependencies = [
  "cairo-native",
  "cairo-vm",
  "flate2",
+ "fs2",
  "pretty_assertions_sorted",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ tracing = "0.1"
 serde_json = "1.0.116"
 serde_with = "3.11.0"
 serde = "1.0.197"
+fs2 = "0.4.3"
 cairo-native = { git = "https://github.com/lambdaclass/cairo_native.git", rev = "6a4efafa26d6a0424dee593d2091206c6e9f428d" }
 anyhow = "1.0"
 # Sequencer Dependencies

--- a/rpc-state-reader/Cargo.toml
+++ b/rpc-state-reader/Cargo.toml
@@ -30,6 +30,7 @@ starknet_gateway = { workspace = true }
 tracing = { workspace = true }
 anyhow.workspace = true
 sierra-emu.workspace = true
+fs2.workspace = true
 
 [dev-dependencies]
 pretty_assertions_sorted = "1.2.3"

--- a/rpc-state-reader/src/cache.rs
+++ b/rpc-state-reader/src/cache.rs
@@ -2,11 +2,13 @@ use std::{
     cell::RefCell,
     collections::{hash_map::Entry, HashMap},
     fs::{self, File},
+    io::Seek,
     path::PathBuf,
 };
 
 use blockifier::state::state_api::{StateReader as BlockifierStateReader, StateResult};
 use cairo_vm::Felt252;
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use starknet::core::types::ContractClass;
@@ -59,8 +61,23 @@ impl Drop for RpcCachedStateReader {
         let path = PathBuf::from(format!("rpc_cache/{}.json", self.reader.block_number));
         let parent = path.parent().unwrap();
         fs::create_dir_all(parent).unwrap();
-        let file = File::create(path).unwrap();
-        serde_json::to_writer_pretty(file, &self.state).unwrap();
+
+        let mut file = File::options()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(path)
+            .unwrap();
+        file.lock_exclusive().unwrap();
+
+        if let Ok(new_state) = serde_json::from_reader::<_, RpcCache>(&file) {
+            merge_cache(self.state.get_mut(), new_state);
+        }
+        file.set_len(0).unwrap();
+        file.seek(std::io::SeekFrom::Start(0)).unwrap();
+
+        serde_json::to_writer_pretty(&file, &self.state).unwrap();
+        file.unlock().unwrap();
     }
 }
 
@@ -70,9 +87,14 @@ impl RpcCachedStateReader {
             let path = PathBuf::from(format!("rpc_cache/{}.json", reader.block_number));
 
             match File::open(path) {
-                Ok(file) => serde_json::from_reader(file).unwrap(),
+                Ok(file) => {
+                    file.lock_shared().unwrap();
+                    let state = serde_json::from_reader(&file).unwrap();
+                    file.unlock().unwrap();
+                    state
+                }
                 Err(_) => {
-                    warn!("Cache for block {} was not found", reader.block_number);
+                    warn!("Failed to read cache for block {}", reader.block_number);
                     RpcCache::default()
                 }
             }
@@ -219,4 +241,19 @@ impl BlockifierStateReader for RpcCachedStateReader {
     ) -> StateResult<starknet_api::core::CompiledClassHash> {
         todo!();
     }
+}
+
+fn merge_cache(cache: &mut RpcCache, other: RpcCache) {
+    if cache.block.is_none() {
+        cache.block = other.block
+    }
+    cache.transactions.extend(other.transactions);
+    cache.contract_classes.extend(other.contract_classes);
+    cache.storage.extend(other.storage);
+    cache.nonces.extend(other.nonces);
+    cache.class_hashes.extend(other.class_hashes);
+    cache
+        .transaction_receipts
+        .extend(other.transaction_receipts);
+    cache.transaction_traces.extend(other.transaction_traces);
 }


### PR DESCRIPTION
Currently, if two replay instances execute the same block at the same time, race conditions can appear when writing to the cache, corrupting it's state.

This PR fixes it by using file locks to ensure that only one process modifies the cache at a time.

I added fs2 as a dependency, as the file lock API of the standard fs crate is nightly only.