### PR TITLE
Add CASM cache

### DIFF
--- a/rpc-state-reader/src/reader.rs
+++ b/rpc-state-reader/src/reader.rs
@@ -1,21 +1,12 @@
-use std::{
-    env, fmt,
-    sync::Arc,
-    thread,
-    time::{Duration, Instant},
-};
+use std::{env, fmt, sync::Arc, thread, time::Duration};
 
 use blockifier::{
     execution::{
-        contract_class::{
-            CompiledClassV0, CompiledClassV0Inner, CompiledClassV1, RunnableCompiledClass,
-        },
+        contract_class::{CompiledClassV0, CompiledClassV0Inner, RunnableCompiledClass},
         native::contract_class::NativeCompiledClassV1,
     },
     state::state_api::{StateReader as BlockifierStateReader, StateResult},
 };
-use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
-use cairo_lang_utils::bigint::BigUintAsHex;
 use cairo_vm::types::program::Program;
 use serde::Serialize;
 use serde_json::Value;
@@ -34,12 +25,12 @@ use starknet_gateway::{
     },
     rpc_state_reader::RpcStateReader as GatewayRpcStateReader,
 };
-use tracing::{info, info_span};
+use tracing::info_span;
 use ureq::json;
 
 use crate::{
     objects::{self, BlockWithTxHahes, RpcTransactionReceipt, RpcTransactionTrace},
-    utils,
+    utils::{self, bytecode_size, get_casm_compiled_class, get_native_executor},
 };
 
 /// Starknet chains supported in Infura.
@@ -299,35 +290,20 @@ fn compile_sierra_cc(
     .entered();
 
     if cfg!(feature = "only_casm") {
-        info!("starting vm contract compilation");
-
-        let pre_compilation_instant = Instant::now();
-
-        let casm_cc =
-        cairo_lang_starknet_classes::casm_contract_class::CasmContractClass::from_contract_class(sierra_cc, false, usize::MAX).unwrap();
-
-        let compilation_time = pre_compilation_instant.elapsed().as_millis();
-
-        tracing::info!(
-            time = compilation_time,
-            size = bytecode_size(&casm_cc.bytecode),
-            "vm contract compilation finished"
-        );
-
-        RunnableCompiledClass::V1(casm_cc.try_into().unwrap())
+        let casm_compiled_class = get_casm_compiled_class(sierra_cc, class_hash);
+        RunnableCompiledClass::V1(casm_compiled_class)
     } else {
         let executor = if cfg!(feature = "with-sierra-emu") {
             let program = Arc::new(sierra_cc.extract_sierra_program().unwrap());
             sierra_emu::VirtualMachine::new_starknet(program, &sierra_cc.entry_points_by_type)
                 .into()
         } else {
-            utils::get_native_executor(&sierra_cc, class_hash).into()
+            get_native_executor(&sierra_cc, class_hash).into()
         };
 
-        let casm = CasmContractClass::from_contract_class(sierra_cc, false, usize::MAX).unwrap();
-        let casm = CompiledClassV1::try_from(casm).unwrap();
+        let casm_compiled_class = get_casm_compiled_class(sierra_cc, class_hash);
 
-        RunnableCompiledClass::V1Native(NativeCompiledClassV1::new(executor, casm))
+        RunnableCompiledClass::V1Native(NativeCompiledClassV1::new(executor, casm_compiled_class))
     }
 }
 
@@ -367,10 +343,6 @@ fn retry(f: impl Fn() -> RPCStateReaderResult<Value>) -> RPCStateReaderResult<Va
 
         thread::sleep(Duration::from_millis(RETRY_SLEEP_MS))
     }
-}
-
-fn bytecode_size(data: &[BigUintAsHex]) -> usize {
-    data.iter().map(|n| n.value.to_bytes_be().len()).sum()
 }
 
 #[cfg(test)]

--- a/rpc-state-reader/src/utils.rs
+++ b/rpc-state-reader/src/utils.rs
@@ -1,12 +1,13 @@
 use std::{
     collections::HashMap,
-    fs,
+    fs::{self, File},
     io::{self, Read},
     path::PathBuf,
     sync::{OnceLock, RwLock},
     time::Instant,
 };
 
+use blockifier::execution::contract_class::CompiledClassV1;
 use cairo_lang_starknet_classes::contract_class::{ContractClass, ContractEntryPoints};
 use cairo_lang_utils::bigint::BigUintAsHex;
 use cairo_native::{executor::AotContractExecutor, OptLevel};
@@ -126,4 +127,48 @@ pub fn get_native_executor(contract: &ContractClass, class_hash: ClassHash) -> A
             executor
         }
     }
+}
+
+pub fn get_casm_compiled_class(class: ContractClass, class_hash: ClassHash) -> CompiledClassV1 {
+    let path = PathBuf::from(format!(
+        "compiled_programs/{}.casm.json",
+        class_hash.to_hex_string(),
+    ));
+
+    let casm_class = if path.exists() {
+        let file = File::open(path).unwrap();
+        serde_json::from_reader(file).unwrap()
+    } else {
+        info!("starting vm contract compilation");
+
+        let pre_compilation_instant = Instant::now();
+
+        let casm_class =
+        cairo_lang_starknet_classes::casm_contract_class::CasmContractClass::from_contract_class(
+            class,
+            false,
+            usize::MAX,
+        )
+        .unwrap();
+
+        let compilation_time = pre_compilation_instant.elapsed().as_millis();
+
+        tracing::info!(
+            time = compilation_time,
+            size = bytecode_size(&casm_class.bytecode),
+            "vm contract compilation finished"
+        );
+
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        let file = File::create(path).unwrap();
+        serde_json::to_writer_pretty(file, &casm_class).unwrap();
+
+        casm_class
+    };
+    CompiledClassV1::try_from(casm_class).unwrap()
+}
+
+pub fn bytecode_size(data: &[BigUintAsHex]) -> usize {
+    data.iter().map(|n| n.value.to_bytes_be().len()).sum()
 }


### PR DESCRIPTION
This PR saves compiled CASM contracts to disk, making VM reexecution faster.

The cached contracts are stored at `compiled_programs/<hash>.casm.json`

As a test, I executed with the VM transaction `0x59bfd720bb72b1063ee3f0c3864019a008a22ef662e5f907012b0e9800f78f0`:
- First execution (no CASM cache): 37.33 seconds
- Second execution (with CASM cache): 16.50 seconds