### PR TITLE
Revert CASM cache

### DIFF
--- a/rpc-state-reader/src/utils.rs
+++ b/rpc-state-reader/src/utils.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    fs::{self, File},
+    fs::{self},
     io::{self, Read},
     path::PathBuf,
     sync::{OnceLock, RwLock},
@@ -129,21 +129,12 @@ pub fn get_native_executor(contract: &ContractClass, class_hash: ClassHash) -> A
     }
 }
 
-pub fn get_casm_compiled_class(class: ContractClass, class_hash: ClassHash) -> CompiledClassV1 {
-    let path = PathBuf::from(format!(
-        "compiled_programs/{}.casm.json",
-        class_hash.to_hex_string(),
-    ));
+pub fn get_casm_compiled_class(class: ContractClass, _class_hash: ClassHash) -> CompiledClassV1 {
+    info!("starting vm contract compilation");
 
-    let casm_class = if path.exists() {
-        let file = File::open(path).unwrap();
-        serde_json::from_reader(file).unwrap()
-    } else {
-        info!("starting vm contract compilation");
+    let pre_compilation_instant = Instant::now();
 
-        let pre_compilation_instant = Instant::now();
-
-        let casm_class =
+    let casm_class =
         cairo_lang_starknet_classes::casm_contract_class::CasmContractClass::from_contract_class(
             class,
             false,
@@ -151,21 +142,14 @@ pub fn get_casm_compiled_class(class: ContractClass, class_hash: ClassHash) -> C
         )
         .unwrap();
 
-        let compilation_time = pre_compilation_instant.elapsed().as_millis();
+    let compilation_time = pre_compilation_instant.elapsed().as_millis();
 
-        tracing::info!(
-            time = compilation_time,
-            size = bytecode_size(&casm_class.bytecode),
-            "vm contract compilation finished"
-        );
+    tracing::info!(
+        time = compilation_time,
+        size = bytecode_size(&casm_class.bytecode),
+        "vm contract compilation finished"
+    );
 
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-
-        let file = File::create(path).unwrap();
-        serde_json::to_writer_pretty(file, &casm_class).unwrap();
-
-        casm_class
-    };
     CompiledClassV1::try_from(casm_class).unwrap()
 }
 


### PR DESCRIPTION
We have a bug in the CASM cache, causing the CI to fail due to race conditions.

This PR reverts it so that we can have the CI working again. Later, we can reimplement the CASM cache correctly.