### PR TITLE
Fix invalid account signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "anyhow",
  "ark-ec 0.4.2",
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "blockifier_reexecution"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "assert_matches",
  "blockifier",
@@ -3934,7 +3934,7 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 [[package]]
 name = "infra_utils"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "tokio",
  "tracing",
@@ -4707,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "mempool_test_utils"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "assert_matches",
  "blockifier",
@@ -5182,7 +5182,7 @@ dependencies = [
 [[package]]
 name = "papyrus_common"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "base64 0.13.1",
  "cairo-lang-starknet-classes",
@@ -5201,7 +5201,7 @@ dependencies = [
 [[package]]
 name = "papyrus_config"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "clap",
  "infra_utils",
@@ -5216,7 +5216,7 @@ dependencies = [
 [[package]]
 name = "papyrus_execution"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "anyhow",
  "blockifier",
@@ -5239,7 +5239,7 @@ dependencies = [
 [[package]]
 name = "papyrus_network_types"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "libp2p",
  "serde",
@@ -5248,7 +5248,7 @@ dependencies = [
 [[package]]
 name = "papyrus_proc_macros"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "quote",
  "syn 2.0.95",
@@ -5258,7 +5258,7 @@ dependencies = [
 [[package]]
 name = "papyrus_rpc"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5292,7 +5292,7 @@ dependencies = [
 [[package]]
 name = "papyrus_storage"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "byteorder",
  "cairo-lang-casm",
@@ -7232,7 +7232,7 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "bitvec",
  "cairo-lang-runner",
@@ -7259,7 +7259,7 @@ dependencies = [
 [[package]]
 name = "starknet_client"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "async-trait",
  "cairo-lang-starknet-classes",
@@ -7286,7 +7286,7 @@ dependencies = [
 [[package]]
 name = "starknet_gateway"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "async-trait",
  "axum",
@@ -7314,7 +7314,7 @@ dependencies = [
 [[package]]
 name = "starknet_gateway_types"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "async-trait",
  "axum",
@@ -7333,7 +7333,7 @@ dependencies = [
 [[package]]
 name = "starknet_mempool_types"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "async-trait",
  "papyrus_network_types",
@@ -7347,7 +7347,7 @@ dependencies = [
 [[package]]
 name = "starknet_sequencer_infra"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "async-trait",
  "hyper 0.14.32",
@@ -7366,7 +7366,7 @@ dependencies = [
 [[package]]
 name = "starknet_sierra_compile"
 version = "0.0.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=bc355ff595095268a698f8075848ec89948791e1#bc355ff595095268a698f8075848ec89948791e1"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=e60ec7d88b59e9fbfec7bdc7094062fb45d17554#e60ec7d88b59e9fbfec7bdc7094062fb45d17554"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-starknet-classes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ fs2 = "0.4.3"
 cairo-native = { git = "https://github.com/lambdaclass/cairo_native.git", rev = "e9151aa8420a138f70febb721f8979d3dd2f7223" }
 anyhow = "1.0"
 # Sequencer Dependencies
-starknet_api = { git = "https://github.com/lambdaclass/sequencer.git", rev = "bc355ff595095268a698f8075848ec89948791e1" } # replay
-blockifier = { git = "https://github.com/lambdaclass/sequencer.git", rev = "bc355ff595095268a698f8075848ec89948791e1", features = ["cairo_native"] } # replay
-starknet_gateway = { git = "https://github.com/lambdaclass/sequencer.git", rev = "bc355ff595095268a698f8075848ec89948791e1" } # replay
-blockifier_reexecution = { git = "https://github.com/lambdaclass/sequencer.git", rev = "bc355ff595095268a698f8075848ec89948791e1" } # replay
+starknet_api = { git = "https://github.com/lambdaclass/sequencer.git", rev = "e60ec7d88b59e9fbfec7bdc7094062fb45d17554" } # replay
+blockifier = { git = "https://github.com/lambdaclass/sequencer.git", rev = "e60ec7d88b59e9fbfec7bdc7094062fb45d17554", features = ["cairo_native"] } # replay
+starknet_gateway = { git = "https://github.com/lambdaclass/sequencer.git", rev = "e60ec7d88b59e9fbfec7bdc7094062fb45d17554" } # replay
+blockifier_reexecution = { git = "https://github.com/lambdaclass/sequencer.git", rev = "e60ec7d88b59e9fbfec7bdc7094062fb45d17554" } # replay

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -7,8 +7,9 @@ use clap::{Parser, Subcommand};
 use rpc_state_reader::cache::RpcCachedStateReader;
 use rpc_state_reader::execution::fetch_transaction_with_state;
 use rpc_state_reader::objects::RpcTransactionReceipt;
-use rpc_state_reader::reader::{RpcChain, RpcStateReader, StateReader};
+use rpc_state_reader::reader::{RpcStateReader, StateReader};
 use starknet_api::block::BlockNumber;
+use starknet_api::core::ChainId;
 use starknet_api::felt;
 use starknet_api::transaction::{TransactionExecutionStatus, TransactionHash};
 use tracing::{debug, error, info, info_span};
@@ -302,12 +303,11 @@ fn main() {
     }
 }
 
-fn parse_network(network: &str) -> RpcChain {
+fn parse_network(network: &str) -> ChainId {
     match network.to_lowercase().as_str() {
-        "mainnet" => RpcChain::MainNet,
-        "testnet" => RpcChain::TestNet,
-        "testnet2" => RpcChain::TestNet2,
-        _ => panic!("Invalid network name, it should be one of: mainnet, testnet, testnet2"),
+        "mainnet" => ChainId::Mainnet,
+        "testnet" => ChainId::Sepolia,
+        _ => panic!("Invalid network name, it should be one of: mainnet, testnet"),
     }
 }
 

--- a/rpc-state-reader/src/execution.rs
+++ b/rpc-state-reader/src/execution.rs
@@ -32,7 +32,9 @@ pub fn fetch_block_context(reader: &impl StateReader) -> anyhow::Result<BlockCon
     let block = reader.get_block_with_tx_hashes()?;
 
     let version = StarknetVersion::try_from(block.header.starknet_version.as_str())?;
-    let versioned_constants = VersionedConstants::get(&version)?.clone();
+    let versioned_constants = VersionedConstants::get(&version)
+        .unwrap_or_else(|_| VersionedConstants::latest_constants())
+        .clone();
 
     let block_info = get_block_info(block.header);
 

--- a/rpc-state-reader/src/execution.rs
+++ b/rpc-state-reader/src/execution.rs
@@ -32,6 +32,8 @@ pub fn fetch_block_context(reader: &impl StateReader) -> anyhow::Result<BlockCon
     let block = reader.get_block_with_tx_hashes()?;
 
     let version = StarknetVersion::try_from(block.header.starknet_version.as_str())?;
+
+    // we must use the starknet constants that corresponds to the starknet transaction's version
     let versioned_constants = VersionedConstants::get(&version)
         .unwrap_or_else(|_| VersionedConstants::latest_constants())
         .clone();

--- a/rpc-state-reader/src/lib.rs
+++ b/rpc-state-reader/src/lib.rs
@@ -11,7 +11,7 @@ mod tests {
     use starknet_api::{
         block::BlockNumber,
         class_hash,
-        core::{ContractAddress, Nonce},
+        core::{ChainId, ContractAddress, Nonce},
         felt,
         hash::StarkHash,
         patricia_key,
@@ -32,7 +32,7 @@ mod tests {
 
     #[test]
     fn test_get_contract_class_cairo1() {
-        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
+        let rpc_state = RpcStateReader::new(ChainId::Mainnet, BlockNumber(700000));
 
         let class_hash =
             class_hash!("0298e56befa6d1446b86ed5b900a9ba51fd2faa683cd6f50e8f833c0fb847216");
@@ -45,7 +45,7 @@ mod tests {
 
     #[test]
     fn test_get_contract_class_cairo0() {
-        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
+        let rpc_state = RpcStateReader::new(ChainId::Mainnet, BlockNumber(700000));
 
         let class_hash =
             class_hash!("025ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918");
@@ -54,7 +54,7 @@ mod tests {
 
     #[test]
     fn test_get_class_hash_at() {
-        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
+        let rpc_state = RpcStateReader::new(ChainId::Mainnet, BlockNumber(700000));
         let address =
             contract_address!("00b081f7ba1efc6fe98770b09a827ae373ef2baa6116b3d2a0bf5154136573a9");
 
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn test_get_nonce_at() {
-        let rpc_state = RpcStateReader::new(RpcChain::TestNet, BlockNumber(400000));
+        let rpc_state = RpcStateReader::new(ChainId::Sepolia, BlockNumber(400000));
         // Contract deployed by xqft which will not be used again, so nonce changes will not break
         // this test.
         let address =
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn test_get_storage_at() {
-        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
+        let rpc_state = RpcStateReader::new(ChainId::Mainnet, BlockNumber(700000));
         let address =
             contract_address!("00b081f7ba1efc6fe98770b09a827ae373ef2baa6116b3d2a0bf5154136573a9");
         let key = StorageKey(patricia_key!(0u128));
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn test_get_transaction() {
-        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
+        let rpc_state = RpcStateReader::new(ChainId::Mainnet, BlockNumber(700000));
         let tx_hash = TransactionHash(
             StarkHash::from_hex("06da92cfbdceac5e5e94a1f40772d6c79d34f011815606742658559ec77b6955")
                 .unwrap(),
@@ -105,7 +105,7 @@ mod tests {
     // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction_trace?transactionHash=0x035673e42bd485ae699c538d8502f730d1137545b22a64c094ecdaf86c59e592
     #[test]
     fn test_get_transaction_trace() {
-        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
+        let rpc_state = RpcStateReader::new(ChainId::Mainnet, BlockNumber(700000));
 
         let tx_hash = TransactionHash(
             StarkHash::from_hex(
@@ -243,7 +243,7 @@ mod tests {
 
     #[test]
     fn test_get_transaction_receipt() {
-        let rpc_state = RpcStateReader::new(RpcChain::MainNet, BlockNumber(700000));
+        let rpc_state = RpcStateReader::new(ChainId::Mainnet, BlockNumber(700000));
         let tx_hash = TransactionHash(
             StarkHash::from_hex("06da92cfbdceac5e5e94a1f40772d6c79d34f011815606742658559ec77b6955")
                 .unwrap(),


### PR DESCRIPTION
Depends on https://github.com/lambdaclass/sequencer/pull/44

Some transactions reverted due to invalid account signature, both in Native and VM.

This PR changes two things that fixed the issue:
- Using sequencer's ChainId, rather than our RpcChain
- Using the appropiate versioned contants, according to the transactions starknet version, rather than using always the latest ones.