### PR TITLE
Update environment variable documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Some environment variable are needed, you can automatically set them by sourcing
 export LLVM_SYS_191_PREFIX=/path/to/llvm-19
 export MLIR_SYS_190_PREFIX=/path/to/llvm-19
 export TABLEGEN_190_PREFIX=/path/to/llvm-19
-export CAIRO_NATIVE_RUNTIME_LIBRARY=/path/to/cairo_native/target/release/libcairo_native_runtime.a
 # RPC
 export RPC_ENDPOINT_MAINNET=rpc.endpoint.mainnet.com
 export RPC_ENDPOINT_TESTNET=rpc.endpoint.testnet.com
@@ -55,14 +54,6 @@ Starknet Replay is currenlty integrated with [Cairo Native](https://github.com/l
 Afterwards, compiling with the feature flag `cairo-native` will enable native execution. You can check out some example test code that uses it under `tests/cairo_native.rs`.
 
 #### Using ahead of time compilation with Native.
-
-Currently cairo-native with AOT needs a runtime library in a known place. For this you need to compile the [cairo-native-runtime](https://github.com/lambdaclass/cairo_native/tree/main/runtime) crate and point the following environment variable to a folder containing the dynamic library. The path **must** be an absolute path.
-
-```bash
-CAIRO_NATIVE_RUNTIME_LIBRARY=/absolute/path/to/cairo-native/target/release/libcairo_native_runtime.a
-```
-
-If you don't do this you will get a linker error when using AOT.
 
 ## replay
 You can use the replay crate to execute transactions or blocks via the CLI. For example:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ export RPC_ENDPOINT_MAINNET=rpc.endpoint.mainnet.com
 export RPC_ENDPOINT_TESTNET=rpc.endpoint.testnet.com
 ```
 
+On macos, you may also need to set the following to avoid linking errors:
+
+```bash
+export LIBRARY_PATH=/opt/homebrew/lib
+```
+
 Once you have installed dependencies and set the needed environment variables, you can build the project and run the tests:
 ```bash
 make build

--- a/env.sh
+++ b/env.sh
@@ -17,17 +17,18 @@ case $(uname) in
   ;;
   Linux)
     # If installed from Debian/Ubuntu repository:
+    LIBRARY_PATH=/opt/homebrew/lib
     LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
     MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
     TABLEGEN_190_PREFIX=/usr/lib/llvm-19
 
+    export LIBRARY_PATH
     export LLVM_SYS_191_PREFIX
     export MLIR_SYS_190_PREFIX
     export TABLEGEN_190_PREFIX
   ;;
 esac
 
-# export CAIRO_NATIVE_RUNTIME_LIBRARY=
 # export RPC_ENDPOINT_MAINNET=
 # export RPC_ENDPOINT_TESTNET=
 
@@ -35,4 +36,3 @@ echo "loaded LLVM environment variables"
 echo "remember you must manually set:"
 echo "- RPC_ENDPOINT_MAINNET=rpc.endpoint.mainnet.com"
 echo "- RPC_ENDPOINT_TESTNET=rpc.endpoint.testnet.com"
-echo "- CAIRO_NATIVE_RUNTIME_LIBRARY=path/to/cairo_native/target/release/libcairo_native_runtime.a"


### PR DESCRIPTION
Update environment variable documentation:

- Removes mention of Native runtime, as it no longer exists.
- Document `LIBRARY_PATH` fix for macos users. 