### PR TITLE
Fix some bugs

### DIFF
--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -156,10 +156,10 @@ fn get_class_executions(call: CallInfo) -> Vec<ClassExecutionInfo> {
         })
         .collect::<Vec<_>>();
 
-    if call.time.is_zero() {
-        panic!("contract time should never be zero, there is a bug somewhere")
-    }
-    let time = call.time - inner_time;
+    let time = call
+        .time
+        .checked_sub(inner_time)
+        .expect("time cannot be negative");
 
     let top_class = ClassExecutionInfo {
         class_hash,

--- a/rpc-state-reader/src/objects.rs
+++ b/rpc-state-reader/src/objects.rs
@@ -128,6 +128,13 @@ pub mod deser {
                 resource_bounds["L1_GAS"] = l1_gas.clone();
                 resource_bounds.as_object_mut().unwrap().remove("l1_gas");
             }
+            if let Some(l1_data_gas) = resource_bounds.get_mut("l1_data_gas") {
+                resource_bounds["L1_DATA_GAS"] = l1_data_gas.clone();
+                resource_bounds
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("l1_data_gas");
+            }
             if let Some(l2_gas) = resource_bounds.get_mut("l2_gas") {
                 resource_bounds["L2_GAS"] = l2_gas.clone();
                 resource_bounds.as_object_mut().unwrap().remove("l2_gas");


### PR DESCRIPTION
Some minor fixes:

- We used to assert that the call info didn't have a time `0`. Turns out that its possible for some call infos to contain the default value. For example, executing an empty constructor: https://github.com/lambdaclass/sequencer/blob/7e7f34e756edcb1f3334aabcc0f8ec3dce40c85a/crates/blockifier/src/execution/entry_point.rs#L436

- Some of the new blocks have the `l1_data_gas` field now. This PR adds support for it, as it used to fail at deserialization.