### PR TITLE
Add 'l2_gas_price' in BlockHeader

### DIFF
--- a/rpc-state-reader/src/execution.rs
+++ b/rpc-state-reader/src/execution.rs
@@ -153,8 +153,8 @@ pub fn get_block_info(header: BlockHeader) -> BlockInfo {
             parse_gas_price(header.l1_gas_price.price_in_fri),
             parse_gas_price(header.l1_data_gas_price.price_in_wei),
             parse_gas_price(header.l1_data_gas_price.price_in_fri),
-            NonzeroGasPrice::MIN,
-            NonzeroGasPrice::MIN,
+            parse_gas_price(header.l2_gas_price.price_in_wei),
+            parse_gas_price(header.l2_gas_price.price_in_fri),
         ),
         use_kzg_da: true,
     }

--- a/rpc-state-reader/src/objects.rs
+++ b/rpc-state-reader/src/objects.rs
@@ -67,6 +67,7 @@ pub struct BlockHeader {
     pub l1_gas_price: ResourcePrice,
     pub l1_data_gas_price: ResourcePrice,
     pub l1_da_mode: L1DataAvailabilityMode,
+    pub l2_gas_price: ResourcePrice,
     pub starknet_version: String,
 }
 


### PR DESCRIPTION
Adds the `l2_gas_price` to `BlockHeader` so it can be deserealized since it was being hardcoded.

Fixes #164 