### PR TITLE
Add missing feature for trace-dump

### DIFF
--- a/replay/Cargo.toml
+++ b/replay/Cargo.toml
@@ -13,7 +13,7 @@ only-native = ["blockifier/only-native"]
 structured_logging = []
 state_dump = ["dep:serde_with", "dep:starknet-types-core"]
 with-sierra-emu = ["rpc-state-reader/with-sierra-emu"]
-with-trace-dump = ["blockifier/with-trace-dump"]
+with-trace-dump = ["blockifier/with-trace-dump", "rpc-state-reader/with-trace-dump"]
 with-libfunc-profiling = [
   "rpc-state-reader/with-libfunc-profiling",
   "dep:starknet-types-core",

--- a/rpc-state-reader/Cargo.toml
+++ b/rpc-state-reader/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # The only_casm feature compiles all the Sierra fetched contracts to CASM.
 # We use this feature to avoid using cairo_native in the Replay crate.
 only_casm = []
-with-sierra-emu = []
+with-sierra-emu = ["blockifier/with-trace-dump"]
 with-trace-dump = ["blockifier/with-trace-dump"]
 with-libfunc-profiling = ["blockifier/with-libfunc-profiling"]
 with-comp-stats = []


### PR DESCRIPTION
We were not enabling the `with-trace-dump` feature on the `rpc-state-reader` so the trace-dump tool could not be used.

Co-authored-by: @JulianGCalderon 