### PR TITLE
Aggregate benchmark results from multiple laps

### DIFF
--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -12,7 +12,7 @@ use crate::execution::TransactionExecution;
 
 #[derive(Serialize, Deserialize)]
 pub struct BenchData {
-    pub txs: Vec<TxBenchData>,
+    pub transactions: Vec<TxBenchData>,
     pub calls: Vec<CallBenchData>,
 }
 
@@ -84,7 +84,7 @@ impl BenchData {
         }
 
         Self {
-            txs: aggregated_txs,
+            transactions: aggregated_txs,
             calls: aggregated_calls,
         }
     }

--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -1,7 +1,7 @@
-use std::time::Duration;
+use std::{collections::BTreeMap, time::Duration};
 
-use blockifier::execution::{call_info::CallInfo, contract_class::TrackedResource};
-use serde::Serialize;
+use blockifier::execution::call_info::CallInfo;
+use serde::{Deserialize, Serialize};
 use starknet_api::{
     block::BlockNumber,
     core::{ClassHash, EntryPointSelector},
@@ -10,83 +10,113 @@ use starknet_api::{
 
 use crate::execution::TransactionExecution;
 
-#[derive(Serialize)]
-pub struct BenchmarkingData {
-    pub transactions: Vec<TransactionExecutionData>,
-    pub calls: Vec<ClassExecutionData>,
+#[derive(Serialize, Deserialize)]
+pub struct TxData {
+    tx_hash: TransactionHash,
+    block_number: BlockNumber,
+    time_ns: u128,
+    gas_consumed: u64,
+    steps: u64,
+    failed: bool,
 }
 
-#[derive(Serialize)]
-pub struct ClassExecutionData {
+#[derive(Serialize, Deserialize)]
+pub struct CallData {
+    tx_hash: TransactionHash,
     class_hash: ClassHash,
     selector: EntryPointSelector,
     time_ns: u128,
     gas_consumed: u64,
     steps: u64,
-    resource: TrackedResource,
+    cairo_native: bool,
 }
 
-#[derive(Serialize)]
-pub struct TransactionExecutionData {
-    hash: TransactionHash,
-    time_ns: u128,
-    gas_consumed: u64,
-    steps: u64,
-    first_call: usize,
-    block_number: u64,
+#[derive(Serialize, Deserialize)]
+pub struct Data {
+    pub txs: Vec<TxData>,
+    pub calls: Vec<CallData>,
 }
 
-pub fn aggregate_executions(
-    executions: Vec<(BlockNumber, Vec<TransactionExecution>)>,
-) -> BenchmarkingData {
-    let mut calls = vec![];
-    let mut transactions = vec![];
+impl Data {
+    pub fn aggregate(txs: &[TransactionExecution]) -> Self {
+        // Group by transaction hash
+        let mut grouped_txs = BTreeMap::new();
+        for tx in txs {
+            grouped_txs.entry(tx.hash).or_insert_with(Vec::new).push(tx);
+        }
 
-    for (block_number, executions) in executions {
-        for execution in executions {
-            let Ok(execution_info) = execution.result else {
-                continue;
-            };
+        let mut aggregated_txs = Vec::new();
+        let mut aggregated_calls = Vec::new();
 
-            let first_class_index = calls.len();
+        // Iterate each transaction group, and aggregate it into a single entry
+        // by dividing the resource usage by the number of executions.
+        for (_, txs) in grouped_txs {
+            let summarized_txs = txs.into_iter().map(summarize_tx).collect::<Vec<_>>();
 
-            let mut gas_consumed = 0;
-            let mut steps = 0;
+            let tx_count = summarized_txs.len();
 
-            if let Some(call) = execution_info.validate_call_info {
-                gas_consumed += call.execution.gas_consumed;
-                steps += call.resources.n_steps as u64;
-                calls.append(&mut get_calls(call));
+            let (mut tx_data, mut calls) = summarized_txs
+                .into_iter()
+                .reduce(|(mut tx_data, mut calls), (other_tx_data, other_calls)| {
+                    tx_data.time_ns += other_tx_data.time_ns;
+                    tx_data.steps += other_tx_data.steps;
+                    tx_data.gas_consumed += other_tx_data.gas_consumed;
+                    for (call, other_call) in calls.iter_mut().zip(other_calls.iter()) {
+                        call.time_ns += other_call.time_ns;
+                        call.steps += other_call.steps;
+                        call.gas_consumed += other_call.gas_consumed;
+                    }
+                    (tx_data, calls)
+                })
+                .expect("we should have at least one execution");
+
+            tx_data.time_ns = tx_data.time_ns.div_ceil(tx_count as u128);
+            tx_data.gas_consumed = tx_data.gas_consumed.div_ceil(tx_count as u64);
+            tx_data.steps = tx_data.steps.div_ceil(tx_count as u64);
+            for call in &mut calls {
+                call.time_ns = call.time_ns.div_ceil(tx_count as u128);
+                call.gas_consumed = call.gas_consumed.div_ceil(tx_count as u64);
+                call.steps = call.steps.div_ceil(tx_count as u64);
             }
-            if let Some(call) = execution_info.execute_call_info {
-                gas_consumed += call.execution.gas_consumed;
-                steps += call.resources.n_steps as u64;
-                calls.append(&mut get_calls(call));
-            }
-            if let Some(call) = execution_info.fee_transfer_call_info {
-                gas_consumed += call.execution.gas_consumed;
-                steps += call.resources.n_steps as u64;
-                calls.append(&mut get_calls(call));
-            }
 
-            transactions.push(TransactionExecutionData {
-                hash: execution.hash,
-                time_ns: execution.time.as_nanos(),
-                first_call: first_class_index,
-                gas_consumed,
-                steps,
-                block_number: block_number.0,
-            });
+            aggregated_txs.push(tx_data);
+            aggregated_calls.append(&mut calls);
+        }
+
+        Self {
+            txs: aggregated_txs,
+            calls: aggregated_calls,
         }
     }
-
-    BenchmarkingData {
-        transactions,
-        calls,
-    }
 }
 
-fn get_calls(call: CallInfo) -> Vec<ClassExecutionData> {
+pub fn summarize_tx(tx: &TransactionExecution) -> (TxData, Vec<CallData>) {
+    let mut tx_data = TxData {
+        tx_hash: tx.hash,
+        block_number: tx.block_number,
+        time_ns: tx.time.as_nanos(),
+        gas_consumed: 0,
+        steps: 0,
+        failed: tx.result.is_err(),
+    };
+
+    let Ok(info) = &tx.result else {
+        return (tx_data, vec![]);
+    };
+
+    let mut calls = Vec::new();
+
+    for call_info in info.non_optional_call_infos() {
+        tx_data.gas_consumed += call_info.execution.gas_consumed;
+        tx_data.steps += call_info.resources.n_steps as u64;
+
+        calls.append(&mut summarize_calls(tx.hash, call_info));
+    }
+
+    (tx_data, calls)
+}
+
+fn summarize_calls(tx_hash: TransactionHash, call: &CallInfo) -> Vec<CallData> {
     // class hash can initially be None, but it is always added before execution
     let class_hash = call.call.class_hash.unwrap();
 
@@ -96,12 +126,12 @@ fn get_calls(call: CallInfo) -> Vec<ClassExecutionData> {
 
     let mut classes = call
         .inner_calls
-        .into_iter()
+        .iter()
         .flat_map(|call| {
             inner_time += call.time;
             inner_gas_consumed += call.execution.gas_consumed;
             inner_steps += call.resources.n_steps as u64;
-            get_calls(call)
+            summarize_calls(tx_hash, call)
         })
         .collect::<Vec<_>>();
 
@@ -120,16 +150,17 @@ fn get_calls(call: CallInfo) -> Vec<ClassExecutionData> {
         .checked_sub(inner_steps)
         .expect("gas cannot be negative");
 
-    let top_class = ClassExecutionData {
+    let top_call = CallData {
+        tx_hash,
         class_hash,
         selector: call.call.entry_point_selector,
+        cairo_native: call.execution.cairo_native,
         time_ns: time.as_nanos(),
         gas_consumed,
-        resource: call.tracked_resource,
         steps,
     };
 
-    classes.push(top_class);
+    classes.push(top_call);
 
     classes
 }

--- a/replay/src/execution.rs
+++ b/replay/src/execution.rs
@@ -35,6 +35,7 @@ pub struct TransactionExecution {
     pub result: TransactionExecutionResult<TransactionExecutionInfo>,
     pub time: Duration,
     pub hash: TransactionHash,
+    pub block_number: BlockNumber,
 }
 
 pub fn execute_block(
@@ -143,6 +144,7 @@ pub fn execute_tx(
         result: execution_result,
         time: execution_time,
         hash: tx_hash,
+        block_number: block_context.block_info().block_number,
     })
 }
 

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -283,7 +283,7 @@ fn main() {
                 }
             }
 
-            let benchmarking_data = benchmark::Data::aggregate(&executions);
+            let benchmarking_data = benchmark::BenchData::aggregate(&executions);
 
             let file = std::fs::File::create(output).unwrap();
             serde_json::to_writer_pretty(file, &benchmarking_data).unwrap();
@@ -346,7 +346,7 @@ fn main() {
                 executions.append(&mut block_executions);
             }
 
-            let benchmarking_data = benchmark::Data::aggregate(&executions);
+            let benchmarking_data = benchmark::BenchData::aggregate(&executions);
 
             let file = std::fs::File::create(output).unwrap();
             serde_json::to_writer_pretty(file, &benchmarking_data).unwrap();

--- a/scripts/benchmark_block.sh
+++ b/scripts/benchmark_block.sh
@@ -34,11 +34,11 @@ LAPS=$4
 DATA_DIR="bench_data"
 mkdir -p $DATA_DIR
 
-log_output="logs-$START-$END-$NET.jsonl"
+log_output="logs-$START-$END-$NET-$LAPS.jsonl"
 native_log_output="$DATA_DIR/native-$log_output"
 vm_log_output="$DATA_DIR/vm-$log_output"
 
-data_output="data-$START-$END-$NET.json"
+data_output="data-$START-$END-$NET-$LAPS.json"
 native_data_output="$DATA_DIR/native-$data_output"
 vm_data_output="$DATA_DIR/vm-$data_output"
 

--- a/scripts/benchmark_tx.sh
+++ b/scripts/benchmark_tx.sh
@@ -34,11 +34,11 @@ LAPS=$4
 DATA_DIR="bench_data"
 mkdir -p $DATA_DIR
 
-log_output="logs-$TX-$NET.jsonl"
+log_output="logs-$TX-$NET-$LAPS.jsonl"
 native_log_output="$DATA_DIR/native-$log_output"
 vm_log_output="$DATA_DIR/vm-$log_output"
 
-data_output="data-$TX-$NET.json"
+data_output="data-$TX-$NET-$LAPS.json"
 native_data_output="$DATA_DIR/native-$data_output"
 vm_data_output="$DATA_DIR/vm-$data_output"
 


### PR DESCRIPTION
Before this PR, we were treating the execution of multiple laps like entirely different executions.

This PR changes it so that, before saving bench data, we aggregate the executions of the same transaction by taking the average time.

This reduces benchmark noise, as well as reducing disk usage.