### PR TITLE
Implement retries with exponential backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,7 +2401,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.2",
  "sha2",
  "smol_str",
  "starknet-types-core",
@@ -2730,7 +2730,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "sha2",
@@ -7507,7 +7507,7 @@ dependencies = [
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
@@ -7588,9 +7588,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -7905,7 +7905,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e211f878258887b3e65dd3c8ff9f530fe109f441a117ee0cdc27f341355032"
 dependencies = [
- "rand 0.9.1",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -8080,7 +8080,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rlp",
  "ruint-macro",
  "serde",
@@ -9063,6 +9063,7 @@ dependencies = [
  "flate2",
  "hex",
  "lockfile",
+ "rand 0.9.2",
  "rayon",
  "reqwest 0.12.20",
  "serde",
@@ -9072,6 +9073,7 @@ dependencies = [
  "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]

--- a/state-reader/Cargo.toml
+++ b/state-reader/Cargo.toml
@@ -29,6 +29,8 @@ cairo-vm = "2.0.1"
 hex = "0.4.3"
 cairo-native.workspace = true
 cairo-lang-starknet-classes.workspace = true
-blockifier_reexecution = { workspace = true }
+blockifier_reexecution.workspace = true 
 lockfile = "0.4.0"
 rayon = "1.10.0"
+rand = "0.9.2"
+tracing.workspace = true

--- a/state-reader/src/error.rs
+++ b/state-reader/src/error.rs
@@ -44,4 +44,6 @@ pub enum StateReaderError {
     LegacyContractWithoutAbi,
     #[error("the received sierra class was invalid")]
     InvalidSierraClass,
+    #[error("reeached the limit of restrys for the RPC request")]
+    RpcRequestTimeout,
 }


### PR DESCRIPTION
The new implementation of the StateReader lacks the ability of retrying sending requests to the RPC node. This sometimes ends up in early timeouts, causing the transactions to fail. This PR adds the retry functionality with an exponential backoff to distribute the requests. 