### PR TITLE
Avoid fail fast when executing transactions 

### DIFF
--- a/replay/src/execution.rs
+++ b/replay/src/execution.rs
@@ -73,13 +73,17 @@ pub fn execute_txs(
     let mut executions = vec![];
 
     for tx_hash in tx_hashes {
-        executions.push(execute_tx(
+        if let Ok(execution) = execute_tx(
             &mut state,
             reader,
             &block_context,
             tx_hash,
             execution_flags.clone(),
-        )?);
+        )
+        .inspect_err(|err| error!("failed to execute transaction: {}", err))
+        {
+            executions.push(execution);
+        }
     }
 
     Ok(executions)
@@ -100,8 +104,7 @@ pub fn execute_tx(
         block_context.block_info().block_number,
         tx_hash,
         execution_flags,
-    )
-    .inspect_err(|err| error!("failed to fetch transaction: {}", err))?;
+    )?;
 
     info!("starting transaction execution");
 


### PR DESCRIPTION
A single transaction error when executing an entire block range would stop the whole execution. This PR changes it so that the error is logged instead.

Closes #202. Blockifier does not support a declare transaction with version 0x0, so the best solution is to avoid exiting when that happens.