### PR TITLE
Automate profiling for Cairo VM

### DIFF
--- a/profiler-sdk/STARKNET.md
+++ b/profiler-sdk/STARKNET.md
@@ -109,3 +109,32 @@ Given a sample, we can determine the crate it belongs to by looking at the symbo
 For the case of sierra contracts, we can't rely on symbol names, but instead rely on the library the current address corresponds to. In the case of our replay, these libraries contain the prefix "0x".
 
 With this knowledge, we can analyze each sample and determine where it belongs to, building a report like the ones exampled above.
+
+# Profiling Cairo VM
+
+We can also process profiles for a Cairo VM execution.
+
+## Obtaining a Profile
+
+First, build the replay crate:
+
+```bash
+cargo build --release --features benchmark,profiling,only_cairo_vm
+```
+
+Then, benchmark a transaction:
+
+```bash
+samply record --  target/release/replay bench-tx <hash> <chain> <block-number> <number-of-runs>
+```
+
+You can obtain a sample profile at: https://share.firefox.dev/477gP4Q.
+
+To make the profile more accurate, we suggest executing the transaction many times (with the `number-of-runs` argument).
+
+## Processing a Profile
+
+To process the samples, run:
+```bash
+cargo run --example cairo-vm sample.json
+```

--- a/profiler-sdk/examples/cairo-vm.rs
+++ b/profiler-sdk/examples/cairo-vm.rs
@@ -112,6 +112,22 @@ fn main() {
                 "<cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor as cairo_vm::hint_processor::hint_processor_definition::HintProcessorLogic>::execute_hint",
                 "cairo_vm::BuiltinHintProcessor::execute_hint",
             ),
+            (
+                "<blockifier::execution::syscalls::hint_processor::SyscallHintProcessor as cairo_vm::hint_processor::hint_processor_definition::HintProcessorLogic>::execute_hint",
+                "blockifier::SyscallHintProcessor::execute_hint",
+            ),
+            (
+                "cairo_vm::vm::runners::builtin_runner::range_check::RangeCheckBuiltinRunner<_>::add_validation_rule::{{closure}}",
+                "cairo_vm::RangeCheckBuiltinRunner<_>::add_validation_rule",
+            ),
+            (
+                "<starknet_types_core::felt::Felt as core::convert::From<num_bigint::bigint::BigInt>>::from",
+                "<starknet_types_core::Felt::from::<BigInt>",
+            ),
+            (
+                "<starknet_types_core::felt::Felt as core::convert::From<&num_bigint::bigint::BigInt>>::from",
+                "<starknet_types_core::Felt::from::<&BigInt>",
+            ),
         ]);
         let funcs_and_names = profile.threads[0]
             .func_table

--- a/profiler-sdk/examples/cairo-vm.rs
+++ b/profiler-sdk/examples/cairo-vm.rs
@@ -1,0 +1,191 @@
+use std::{collections::HashMap, fs::File};
+
+use itertools::Itertools;
+use profiler_sdk::{
+    schema::{IndexIntoResourceTable, Profile},
+    transforms::{
+        collapse_recursion, collapse_resource, collapse_subtree, focus_on_function, merge_function,
+        rename_function,
+    },
+    tree::Tree,
+};
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("expected profile path as first argument");
+    let file = File::open(path).expect("failed to open profile");
+    let mut profile: Profile =
+        serde_json::from_reader(file).expect("failed to deserialize profile");
+
+    {
+        let main_resource = {
+            let main_function = profile.threads[0]
+                .func_table
+                .name
+                .iter()
+                .position(|&name_idx| profile.shared.string_array[name_idx] == "main")
+                .expect("main function should exist");
+            let main_resource: Option<IndexIntoResourceTable> =
+                profile.threads[0].func_table.resource[main_function].into();
+            main_resource.expect("main resource should exist")
+        };
+
+        // Collapse all resources except main resource.
+        for resource_idx in 0..profile.threads[0].resource_table.length {
+            if resource_idx != main_resource {
+                collapse_resource(&mut profile, 0, resource_idx);
+            }
+        }
+    }
+
+    // Focus on execute
+    {
+        let func = profile.threads[0]
+            .func_table
+            .name
+            .iter()
+            .position(|&name_idx| {
+                &profile.shared.string_array[name_idx]
+                    == "blockifier::execution::execution_utils::execute_entry_point_call_wrapper"
+            })
+            .expect("failed to find func");
+        focus_on_function(&mut profile, 0, func);
+        collapse_recursion(&mut profile, 0, func);
+    }
+
+    // Collapse functions
+    {
+        let funcs = profile.threads[0]
+            .func_table
+            .name
+            .iter()
+            .positions(|&name_idx| {
+                let name = &profile.shared.string_array[name_idx];
+                name == "<blockifier::execution::deprecated_syscalls::hint_processor::DeprecatedSyscallHintProcessor as cairo_vm::hint_processor::hint_processor_definition::HintProcessorLogic>::execute_hint" ||
+                name == "blockifier::execution::deprecated_entry_point_execution::finalize_execution" || 
+                name == "blockifier::execution::deprecated_entry_point_execution::initialize_execution_context" || 
+                name == "blockifier::execution::deprecated_entry_point_execution::prepare_call_arguments" || 
+                name == "cairo_vm::vm::runners::cairo_runner::CairoRunner::get_hint_data" ||
+                name == "cairo_vm::vm::runners::cairo_runner::CairoRunner::initialize_function_entrypoint" ||
+                name == "cairo_vm::vm::runners::cairo_runner::CairoRunner::initialize_vm" ||
+                name == "cairo_vm::vm::security::verify_secure_runner" ||
+                name == "cairo_vm::vm::vm_core::VirtualMachine::step_instruction" ||
+                name == "cairo_vm::vm::vm_core::VirtualMachine::verify_auto_deductions" ||
+                name == "cairo_vm::vm::vm_memory::memory_segments::MemorySegmentManager::gen_cairo_arg" ||
+                name == "core::ptr::drop_in_place<cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData>"
+            })
+            .collect_vec();
+
+        for func in funcs {
+            collapse_subtree(&mut profile, 0, func);
+        }
+    }
+
+    // Merge functions
+    {
+        let funcs = profile.threads[0]
+            .func_table
+            .name
+            .iter()
+            .positions(|&name_idx| {
+                let name = &profile.shared.string_array[name_idx];
+                name == "blockifier::execution::execution_utils::execute_entry_point_call" ||
+                    name == "blockifier::execution::deprecated_entry_point_execution::execute_entry_point_call" ||
+                    name == "blockifier::execution::deprecated_entry_point_execution::run_entry_point" ||
+                    name == "<blockifier::execution::deprecated_syscalls::hint_processor::DeprecatedSyscallHintProcessor as cairo_vm::vm::runners::cairo_runner::ResourceTracker>::consume_step" ||
+                    name == "<blockifier::execution::deprecated_syscalls::hint_processor::DeprecatedSyscallHintProcessor as cairo_vm::vm::runners::cairo_runner::ResourceTracker>::consumed" ||
+                    name == "<cairo_vm::vm::runners::cairo_runner::RunResources as cairo_vm::vm::runners::cairo_runner::ResourceTracker>::consume_step" ||
+                    name == "cairo_vm::vm::runners::cairo_runner::CairoRunner::initialize_vm" ||
+                    name == "cairo_vm::vm::security::verify_secure_runner" ||
+                    name == "cairo_vm::vm::vm_core::VirtualMachine::verify_auto_deductions" ||
+                    name == "cairo_vm::vm::vm_memory::memory_segments::MemorySegmentManager::gen_cairo_arg" ||
+                    name == "starknet_types_core::felt::primitive_conversions::<impl core::convert::From<u128> for starknet_types_core::felt::Felt>::from" ||
+                    name == "libsystem_c.dylib" ||
+                    name == "libsystem_kernel.dylib" ||
+                    name == "libsystem_malloc.dylib" ||
+                    name == "libsystem_platform.dylib" ||
+                    name == "std::sys::pal::unix::time::Timespec::now" ||
+                    name == "std::time::Instant::elapsed" ||
+                    name.starts_with("__rustc") || 
+                    name.starts_with("<alloc") ||
+                    name.starts_with("<unknown") ||
+                    name.starts_with("alloc") 
+            })
+            .collect_vec();
+        for func in funcs {
+            merge_function(&mut profile, 0, func);
+        }
+    }
+
+    // Rename functions
+    {
+        let renames = HashMap::from([
+            (
+                "<blockifier::execution::deprecated_syscalls::hint_processor::DeprecatedSyscallHintProcessor as cairo_vm::hint_processor::hint_processor_definition::HintProcessorLogic>::execute_hint",
+                "blockifier::execute_hint",
+            ),
+            (
+                "blockifier::execution::deprecated_entry_point_execution::finalize_execution",
+                "blockifier::finalize_execution",
+            ),
+            (
+                "blockifier::execution::deprecated_entry_point_execution::initialize_execution_context",
+                "blockifier::initialize_execution_context",
+            ),
+            (
+                "blockifier::execution::deprecated_entry_point_execution::prepare_call_arguments",
+                "blockifier::prepare_call_arguments",
+            ),
+            (
+                "blockifier::execution::execution_utils::execute_entry_point_call_wrapper",
+                "blockifier::execute_entry_point_call_wrapper",
+            ),
+            (
+                "cairo_vm::vm::runners::cairo_runner::CairoRunner::get_hint_data",
+                "cairo_vm::get_hint_data",
+            ),
+            (
+                "cairo_vm::vm::runners::cairo_runner::CairoRunner::initialize_function_entrypoint",
+                "cairo_vm::initialize_function_entrypoint",
+            ),
+            (
+                "cairo_vm::vm::runners::cairo_runner::CairoRunner::run_from_entrypoint",
+                "cairo_vm::run_from_entrypoint",
+            ),
+            (
+                "cairo_vm::vm::runners::cairo_runner::CairoRunner::run_until_pc",
+                "cairo_vm::un_until_pc",
+            ),
+            (
+                "cairo_vm::vm::vm_core::VirtualMachine::step",
+                "cairo_vm::step",
+            ),
+            (
+                "cairo_vm::vm::vm_core::VirtualMachine::step_instruction",
+                "cairo_vm::step_instruction",
+            ),
+            (
+                "core::ptr::drop_in_place<cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData>",
+                "drop_in_place<cairo_vm::HintProcessorData>",
+            ),
+        ]);
+        let funcs_and_names = profile.threads[0]
+            .func_table
+            .name
+            .iter()
+            .enumerate()
+            .filter_map(|(func_idx, &name_idx)| {
+                let name = profile.shared.string_array[name_idx].as_str();
+                let new_name = renames.get(name)?.to_string();
+                Some((func_idx, new_name))
+            })
+            .collect_vec();
+
+        for (func_idx, new_name) in funcs_and_names {
+            rename_function(&mut profile, 0, func_idx, new_name);
+        }
+    }
+
+    println!("{}", Tree::from_profile(&profile, 0));
+}

--- a/profiler-sdk/examples/cairo-vm.rs
+++ b/profiler-sdk/examples/cairo-vm.rs
@@ -62,19 +62,15 @@ fn main() {
             .iter()
             .positions(|&name_idx| {
                 let name = &profile.shared.string_array[name_idx];
-                name == "blockifier::execution::deprecated_syscalls::deprecated_syscall_executor::execute_next_deprecated_syscall" ||
-                name == "<cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor as cairo_vm::hint_processor::hint_processor_definition::HintProcessorLogic>::execute_hint" ||
-                name == "blockifier::execution::deprecated_entry_point_execution::finalize_execution" || 
-                name == "blockifier::execution::deprecated_entry_point_execution::initialize_execution_context" || 
-                name == "blockifier::execution::deprecated_entry_point_execution::prepare_call_arguments" || 
-                name == "cairo_vm::vm::runners::cairo_runner::CairoRunner::get_hint_data" ||
-                name == "cairo_vm::vm::runners::cairo_runner::CairoRunner::initialize_function_entrypoint" ||
-                name == "cairo_vm::vm::runners::cairo_runner::CairoRunner::initialize_vm" ||
-                name == "cairo_vm::vm::security::verify_secure_runner" ||
-                name == "cairo_vm::vm::vm_core::VirtualMachine::step_instruction" ||
-                name == "cairo_vm::vm::vm_core::VirtualMachine::verify_auto_deductions" ||
-                name == "cairo_vm::vm::vm_memory::memory_segments::MemorySegmentManager::gen_cairo_arg" ||
-                name == "core::ptr::drop_in_place<cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData>"
+                name == "cairo_vm::vm::vm_core::VirtualMachine::deduce_memory_cell"
+                    || name == "cairo_vm::vm::vm_core::VirtualMachine::insert_deduced_operands"
+                    || name == "blockifier::execution::deprecated_syscalls::deprecated_syscall_executor::execute_next_deprecated_syscall"
+                    || name == "<cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor as cairo_vm::hint_processor::hint_processor_definition::HintProcessorLogic>::execute_hint"
+                    || name == "cairo_vm::vm::runners::cairo_runner::CairoRunner::get_hint_data"
+                    || name == "core::ptr::drop_in_place<alloc::vec::Vec<alloc::boxed::Box<dyn core::any::Any>>>"
+                    || name == "cairo_vm::vm::runners::cairo_runner::CairoRunner::initialize_function_entrypoint"
+                    || name == "core::ptr::drop_in_place<cairo_vm::vm::runners::cairo_runner::CairoRunner>"
+                    || name == "cairo_vm::vm::runners::cairo_runner::CairoRunner::new_v2"
             })
             .collect_vec();
 
@@ -91,29 +87,9 @@ fn main() {
             .iter()
             .positions(|&name_idx| {
                 let name = &profile.shared.string_array[name_idx];
-                name == "blockifier::execution::execution_utils::execute_entry_point_call" ||
-                    name == "blockifier::execution::deprecated_entry_point_execution::execute_entry_point_call" ||
-                    name == "blockifier::execution::deprecated_entry_point_execution::run_entry_point" ||
-                    name == "<blockifier::execution::deprecated_syscalls::hint_processor::DeprecatedSyscallHintProcessor as cairo_vm::vm::runners::cairo_runner::ResourceTracker>::consume_step" ||
-                    name == "<blockifier::execution::deprecated_syscalls::hint_processor::DeprecatedSyscallHintProcessor as cairo_vm::vm::runners::cairo_runner::ResourceTracker>::consumed" ||
-                    name == "<cairo_vm::vm::runners::cairo_runner::RunResources as cairo_vm::vm::runners::cairo_runner::ResourceTracker>::consume_step" ||
-                    name == "cairo_vm::vm::runners::cairo_runner::CairoRunner::initialize_vm" ||
-                    name == "cairo_vm::vm::security::verify_secure_runner" ||
-                    name == "cairo_vm::vm::vm_core::VirtualMachine::verify_auto_deductions" ||
-                    name == "cairo_vm::vm::vm_memory::memory_segments::MemorySegmentManager::gen_cairo_arg" ||
-                    name == "starknet_types_core::felt::primitive_conversions::<impl core::convert::From<u128> for starknet_types_core::felt::Felt>::from" ||
-                    name == "phf::map::Map<K,V>::get_entry" ||
-                    name == "core::ptr::drop_in_place<cairo_vm::vm::errors::hint_errors::HintError>" ||
-                    name == "libsystem_c.dylib" ||
-                    name == "libsystem_kernel.dylib" ||
-                    name == "libsystem_malloc.dylib" ||
-                    name == "libsystem_platform.dylib" ||
-                    name == "std::sys::pal::unix::time::Timespec::now" ||
-                    name == "std::time::Instant::elapsed" ||
-                    name.starts_with("__rustc") || 
-                    name.starts_with("<alloc") ||
-                    name.starts_with("<unknown") ||
-                    name.starts_with("alloc") 
+                name == "blockifier::execution::execution_utils::execute_entry_point_call"
+                    || name == "blockifier::execution::deprecated_entry_point_execution::execute_entry_point_call"
+                    || name == "blockifier::execution::deprecated_entry_point_execution::run_entry_point"
             })
             .collect_vec();
         for func in funcs {
@@ -126,7 +102,7 @@ fn main() {
         let renames = HashMap::from([
             (
                 "<blockifier::execution::deprecated_syscalls::hint_processor::DeprecatedSyscallHintProcessor as cairo_vm::hint_processor::hint_processor_definition::HintProcessorLogic>::execute_hint",
-                "blockifier::execute_hint",
+                "blockifier::DeprecatedSyscallHintProcessor::execute_hint",
             ),
             (
                 "blockifier::execution::deprecated_syscalls::deprecated_syscall_executor::execute_next_deprecated_syscall",
@@ -134,51 +110,7 @@ fn main() {
             ),
             (
                 "<cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor as cairo_vm::hint_processor::hint_processor_definition::HintProcessorLogic>::execute_hint",
-                "cairo_vm::execute_hint",
-            ),
-            (
-                "blockifier::execution::deprecated_entry_point_execution::finalize_execution",
-                "blockifier::finalize_execution",
-            ),
-            (
-                "blockifier::execution::deprecated_entry_point_execution::initialize_execution_context",
-                "blockifier::initialize_execution_context",
-            ),
-            (
-                "blockifier::execution::deprecated_entry_point_execution::prepare_call_arguments",
-                "blockifier::prepare_call_arguments",
-            ),
-            (
-                "blockifier::execution::execution_utils::execute_entry_point_call_wrapper",
-                "blockifier::execute_entry_point_call_wrapper",
-            ),
-            (
-                "cairo_vm::vm::runners::cairo_runner::CairoRunner::get_hint_data",
-                "cairo_vm::get_hint_data",
-            ),
-            (
-                "cairo_vm::vm::runners::cairo_runner::CairoRunner::initialize_function_entrypoint",
-                "cairo_vm::initialize_function_entrypoint",
-            ),
-            (
-                "cairo_vm::vm::runners::cairo_runner::CairoRunner::run_from_entrypoint",
-                "cairo_vm::run_from_entrypoint",
-            ),
-            (
-                "cairo_vm::vm::runners::cairo_runner::CairoRunner::run_until_pc",
-                "cairo_vm::un_until_pc",
-            ),
-            (
-                "cairo_vm::vm::vm_core::VirtualMachine::step",
-                "cairo_vm::step",
-            ),
-            (
-                "cairo_vm::vm::vm_core::VirtualMachine::step_instruction",
-                "cairo_vm::step_instruction",
-            ),
-            (
-                "core::ptr::drop_in_place<cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData>",
-                "drop_in_place<cairo_vm::HintProcessorData>",
+                "cairo_vm::BuiltinHintProcessor::execute_hint",
             ),
         ]);
         let funcs_and_names = profile.threads[0]
@@ -198,5 +130,7 @@ fn main() {
         }
     }
 
-    println!("{}", Tree::from_profile(&profile, 0));
+    let mut tree = Tree::from_profile(&profile, 0);
+    tree.prune(0.01);
+    println!("{}", tree);
 }

--- a/profiler-sdk/examples/cairo-vm.rs
+++ b/profiler-sdk/examples/cairo-vm.rs
@@ -62,7 +62,8 @@ fn main() {
             .iter()
             .positions(|&name_idx| {
                 let name = &profile.shared.string_array[name_idx];
-                name == "<blockifier::execution::deprecated_syscalls::hint_processor::DeprecatedSyscallHintProcessor as cairo_vm::hint_processor::hint_processor_definition::HintProcessorLogic>::execute_hint" ||
+                name == "blockifier::execution::deprecated_syscalls::deprecated_syscall_executor::execute_next_deprecated_syscall" ||
+                name == "<cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor as cairo_vm::hint_processor::hint_processor_definition::HintProcessorLogic>::execute_hint" ||
                 name == "blockifier::execution::deprecated_entry_point_execution::finalize_execution" || 
                 name == "blockifier::execution::deprecated_entry_point_execution::initialize_execution_context" || 
                 name == "blockifier::execution::deprecated_entry_point_execution::prepare_call_arguments" || 
@@ -101,6 +102,8 @@ fn main() {
                     name == "cairo_vm::vm::vm_core::VirtualMachine::verify_auto_deductions" ||
                     name == "cairo_vm::vm::vm_memory::memory_segments::MemorySegmentManager::gen_cairo_arg" ||
                     name == "starknet_types_core::felt::primitive_conversions::<impl core::convert::From<u128> for starknet_types_core::felt::Felt>::from" ||
+                    name == "phf::map::Map<K,V>::get_entry" ||
+                    name == "core::ptr::drop_in_place<cairo_vm::vm::errors::hint_errors::HintError>" ||
                     name == "libsystem_c.dylib" ||
                     name == "libsystem_kernel.dylib" ||
                     name == "libsystem_malloc.dylib" ||
@@ -124,6 +127,14 @@ fn main() {
             (
                 "<blockifier::execution::deprecated_syscalls::hint_processor::DeprecatedSyscallHintProcessor as cairo_vm::hint_processor::hint_processor_definition::HintProcessorLogic>::execute_hint",
                 "blockifier::execute_hint",
+            ),
+            (
+                "blockifier::execution::deprecated_syscalls::deprecated_syscall_executor::execute_next_deprecated_syscall",
+                "blockifier::execute_next_deprecated_syscall",
+            ),
+            (
+                "<cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor as cairo_vm::hint_processor::hint_processor_definition::HintProcessorLogic>::execute_hint",
+                "cairo_vm::execute_hint",
             ),
             (
                 "blockifier::execution::deprecated_entry_point_execution::finalize_execution",

--- a/profiler-sdk/src/transforms.rs
+++ b/profiler-sdk/src/transforms.rs
@@ -356,3 +356,13 @@ pub fn merge_function(
     thread.stack_table = new_stack_table;
     thread.samples = new_sample_table;
 }
+
+pub fn rename_function(
+    profile: &mut Profile,
+    thread_idx: usize,
+    function_to_rename: IndexIntoFuncTable,
+    new_name: String,
+) {
+    let name_idx = profile.threads[thread_idx].func_table.name[function_to_rename];
+    profile.shared.string_array[name_idx] = new_name;
+}


### PR DESCRIPTION
This PR adds support for automating the processing of a Cairo VM transaction profile.

The processed profile looks like this:
```
│ RATIO │  TOTAL  │  SELF   │ TREE
│       │         │         │
│ 100.0 │ 140761  │ 20      │ blockifier::execution::execution_utils::execute_entry_point_call_wrapper
│ 100.0 │ 140741  │ 345     │ └─ blockifier::execution::entry_point_execution::execute_entry_point_call
│ 93.6  │ 131805  │ 310     │    ├─ cairo_vm::vm::runners::cairo_runner::CairoRunner::run_from_entrypoint
│ 87.9  │ 123752  │ 5328    │    │  ├─ cairo_vm::vm::runners::cairo_runner::CairoRunner::run_until_pc
│ 82.1  │ 115543  │ 2873    │    │  │  ├─ cairo_vm::vm::vm_core::VirtualMachine::step
│ 69.6  │ 98017   │ 6588    │    │  │  │  ├─ cairo_vm::vm::vm_core::VirtualMachine::step_instruction
│ 63.9  │ 89940   │ 26649   │    │  │  │  │  ├─ cairo_vm::vm::vm_core::VirtualMachine::run_instruction
│ 31.2  │ 43928   │ 22438   │    │  │  │  │  │  ├─ cairo_vm::vm::vm_core::VirtualMachine::compute_operands
│ 8.6   │ 12071   │ 12071   │    │  │  │  │  │  │  ├─ cairo_vm::vm::vm_memory::memory::Memory::get
│ 3.5   │ 4934    │ 4934    │    │  │  │  │  │  │  ├─ cairo_vm::vm::vm_core::VirtualMachine::deduce_memory_cell
│ 3.2   │ 4485    │ 4485    │    │  │  │  │  │  │  └─ cairo_vm::vm::context::run_context::RunContext::compute_op1_addr
│ 9.9   │ 13881   │ 9350    │    │  │  │  │  │  ├─ cairo_vm::vm::vm_memory::memory::Memory::insert
│ 2.1   │ 2966    │ 30      │    │  │  │  │  │  │  ├─ alloc::raw_vec::finish_grow
│ 2.1   │ 2936    │ 963     │    │  │  │  │  │  │  │  └─ __rustc::__rdl_realloc
│ 1.4   │ 1973    │ 1973    │    │  │  │  │  │  │  │     └─ libsystem_platform.dylib
│ 1.1   │ 1565    │ 1       │    │  │  │  │  │  │  └─ alloc::raw_vec::RawVecInner<A>::reserve::do_reserve_and_handle
│ 1.1   │ 1564    │ 0       │    │  │  │  │  │  │     └─ alloc::raw_vec::finish_grow
│ 1.1   │ 1564    │ 1564    │    │  │  │  │  │  │        └─ __rustc::__rdl_realloc
│ 3.9   │ 5482    │ 3998    │    │  │  │  │  │  └─ cairo_vm::vm::vm_memory::memory::Memory::validate_memory_cell
│ 1.1   │ 1484    │ 1484    │    │  │  │  │  │     └─ cairo_vm::RangeCheckBuiltinRunner<_>::add_validation_rule
│ 1.1   │ 1489    │ 1489    │    │  │  │  │  └─ cairo_vm::vm::vm_core::VirtualMachine::decode_current_instruction
│ 10.4  │ 14653   │ 1019    │    │  │  │  └─ blockifier::SyscallHintProcessor::execute_hint
│ 9.7   │ 13634   │ 5441    │    │  │  │     └─ cairo_lang_runner::casm_run::execute_core_hint
│ 3.5   │ 4984    │ 1       │    │  │  │        ├─ starknet_types_core::felt::Felt::sqrt
│ 3.5   │ 4983    │ 4983    │    │  │  │        │  └─ lambdaworks_math::field::traits::IsPrimeField::sqrt
│ 2.3   │ 3209    │ 810     │    │  │  │        └─ cairo_lang_runner::casm_run::get_val
│ 1.7   │ 2399    │ 258     │    │  │  │           └─ <starknet_types_core::Felt::from::<BigInt>
│ 1.5   │ 2141    │ 685     │    │  │  │              └─ <starknet_types_core::Felt::from::<&BigInt>
│ 1.0   │ 1456    │ 1456    │    │  │  │                 └─ starknet_types_core::felt::Felt::from_bytes_le_slice
│ 2.0   │ 2881    │ 2881    │    │  │  └─ cairo_vm::vm::runners::cairo_runner::CairoRunner::get_hint_data
│ 5.5   │ 7743    │ 7743    │    │  └─ cairo_vm::vm::runners::cairo_runner::CairoRunner::initialize_function_entrypoint
│ 3.8   │ 5388    │ 34      │    ├─ blockifier::execution::entry_point_execution::initialize_execution_context_with_runner_mode
│ 3.8   │ 5354    │ 15      │    │  └─ blockifier::execution::entry_point_execution::prepare_program_extra_data
│ 3.8   │ 5339    │ 2172    │    │     └─ cairo_vm::vm::vm_memory::memory::Memory::insert
│ 2.2   │ 3167    │ 2       │    │        └─ alloc::raw_vec::finish_grow
│ 2.2   │ 3165    │ 1045    │    │           └─ __rustc::__rdl_realloc
│ 1.5   │ 2120    │ 2120    │    │              └─ libsystem_platform.dylib
│ 2.3   │ 3203    │ 1255    │    └─ blockifier::execution::entry_point_execution::finalize_execution
│ 1.4   │ 1948    │ 1948    │       └─ core::ptr::drop_in_place<cairo_vm::vm::runners::cairo_runner::CairoRunner>
```