### PR TITLE
Use rm -f when building mux.sh binaries

### DIFF
--- a/replay/Cargo.toml
+++ b/replay/Cargo.toml
@@ -38,7 +38,7 @@ cairo-lang-sierra = { workspace = true, optional = true }
 clap = { version = "4.5.18", features = ["derive"] }
 # logs
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 # serialization
 serde.workspace = true
 serde_json.workspace = true

--- a/scripts/mux.sh
+++ b/scripts/mux.sh
@@ -105,13 +105,13 @@ range() {
 	if [ "$SKIP" != "native" ]; then
 		echo "Building replay for Cairo Native"
 		cargo build --quiet --release --features structured_logging,state_dump
-		rm ./target/release/replay-native
+		rm -f ./target/release/replay-native
 		mv ./target/release/replay ./target/release/replay-native
 	fi
 	if [ "$SKIP" != "vm" ]; then
 		echo "Building replay for Cairo VM"
 		cargo build --quiet --release --features structured_logging,state_dump,only_cairo_vm
-		rm ./target/release/replay-vm
+		rm -f ./target/release/replay-vm
 		mv ./target/release/replay ./target/release/replay-vm
 	fi
 


### PR DESCRIPTION
Use rm -f when building mux.sh binaries, to ignore the error if the file does not exist.