### PR TITLE
Generate state_dump even on failure

### DIFF
--- a/replay/src/benchmark.rs
+++ b/replay/src/benchmark.rs
@@ -44,7 +44,6 @@ pub struct TxBenchData {
     time_ns: u128,
     gas_consumed: u64,
     steps: u64,
-    failed: bool,
 }
 
 impl BenchData {
@@ -107,16 +106,11 @@ pub fn summarize_tx(tx: &TransactionExecution) -> (TxBenchData, Vec<CallBenchDat
         time_ns: tx.time.as_nanos(),
         gas_consumed: 0,
         steps: 0,
-        failed: tx.result.is_err(),
-    };
-
-    let Ok(info) = &tx.result else {
-        return (tx_data, vec![]);
     };
 
     let mut calls = Vec::new();
 
-    for call_info in info.non_optional_call_infos() {
+    for call_info in tx.info.non_optional_call_infos() {
         tx_data.gas_consumed += call_info.execution.gas_consumed;
         tx_data.steps += call_info.resources.n_steps as u64;
 

--- a/replay/src/block_composition.rs
+++ b/replay/src/block_composition.rs
@@ -4,17 +4,14 @@ use std::{
     path::Path,
 };
 
-use blockifier::{
-    execution::call_info::CallInfo,
-    transaction::{errors::TransactionExecutionError, objects::TransactionExecutionInfo},
-};
+use blockifier::{execution::call_info::CallInfo, transaction::objects::TransactionExecutionInfo};
 use serde::Serialize;
 use starknet_api::core::{ClassHash, EntryPointSelector};
 
 type BlockExecutionInfo = Vec<(
     u64,    // block number
     String, // block timestamp
-    Vec<Result<TransactionExecutionInfo, TransactionExecutionError>>,
+    Vec<TransactionExecutionInfo>,
 )>;
 
 #[derive(Debug, Serialize)]
@@ -57,8 +54,7 @@ pub fn save_entry_point_execution(
     for (block_number, block_timestamp, executions) in executions {
         let entrypoints = executions
             .into_iter()
-            .map(|execution_rst| {
-                let execution = execution_rst.unwrap();
+            .map(|execution| {
                 let mut block_entry_point = TxEntryPoint {
                     validate_call_info: None,
                     execute_call_info: None,

--- a/replay/src/execution.rs
+++ b/replay/src/execution.rs
@@ -5,7 +5,10 @@ use blockifier::{
     blockifier_versioned_constants::VersionedConstants,
     bouncer::BouncerConfig,
     context::BlockContext,
-    state::{cached_state::CachedState, state_api::StateReader},
+    state::{
+        cached_state::{CachedState, TransactionalState},
+        state_api::StateReader,
+    },
     transaction::{
         account_transaction::ExecutionFlags, objects::TransactionExecutionInfo,
         transaction_execution::Transaction as BlockifierTransaction,
@@ -73,6 +76,7 @@ pub fn execute_txs(
     let mut executions = vec![];
 
     for tx_hash in tx_hashes {
+        let mut state = TransactionalState::create_transactional(&mut state);
         let execution_result = execute_tx(
             &mut state,
             reader,
@@ -90,6 +94,7 @@ pub fn execute_txs(
         );
 
         executions.push(execution_result);
+        state.commit();
     }
 
     Ok(executions)


### PR DESCRIPTION
Refactors the execution module to always generate a state_dump, even if the transaction fails to execute.

To do this, I created a new function `execute_and_process_tx` that wraps `execute_tx`, and processes the result of the transaction, that is:
- Create state dump (always).
- Create libfunc profile.
- Log the result.

Also, we were returning `Result<TransactionExecution>`, where `TransactionExecution` also contains a `Result`, I unified both results into a single `Result<TransactionExecution`, where `TransactionExecution` now doesn't contain `Result`. This allows us to handle the error case more easily.