### PR TITLE
Update Native dependency to (potential) 0.9.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 [[package]]
 name = "apollo_class_manager_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_compile_to_casm_types",
  "apollo_infra",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "apollo_compilation_utils"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-sierra",
@@ -823,7 +823,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_casm"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_compile_to_casm_types",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_casm_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_infra",
  "apollo_metrics",
@@ -861,7 +861,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_compile_to_native_types",
@@ -874,7 +874,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_config",
  "serde",
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "apollo_config"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_infra_utils",
  "clap",
@@ -902,7 +902,7 @@ dependencies = [
 [[package]]
 name = "apollo_gateway"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_class_manager_types",
  "apollo_config",
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "apollo_gateway_config"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_config",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "apollo_gateway_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_infra",
  "apollo_network_types",
@@ -975,7 +975,7 @@ dependencies = [
 [[package]]
 name = "apollo_infra"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_config",
  "apollo_infra_utils",
@@ -998,7 +998,7 @@ dependencies = [
 [[package]]
 name = "apollo_infra_utils"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_proc_macros",
  "assert-json-diff",
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "apollo_l1_endpoint_monitor_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_infra",
  "apollo_metrics",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "apollo_mempool_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_infra",
  "apollo_metrics",
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "apollo_metrics"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "indexmap 2.11.1",
  "metrics",
@@ -1063,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "apollo_network_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "lazy_static",
  "libp2p",
@@ -1073,7 +1073,7 @@ dependencies = [
 [[package]]
 name = "apollo_proc_macros"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "apollo_rpc"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "anyhow",
  "apollo_class_manager_types",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "apollo_rpc_execution"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "anyhow",
  "apollo_class_manager_types",
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "apollo_sierra_compilation_config"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_config",
  "serde",
@@ -1153,7 +1153,7 @@ dependencies = [
 [[package]]
 name = "apollo_sizeof"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_sizeof_macros",
  "starknet-types-core",
@@ -1162,7 +1162,7 @@ dependencies = [
 [[package]]
 name = "apollo_sizeof_macros"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1172,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "apollo_starknet_client"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_config",
  "async-trait",
@@ -1198,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "apollo_state_sync_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_infra",
  "apollo_metrics",
@@ -1218,7 +1218,7 @@ dependencies = [
 [[package]]
 name = "apollo_storage"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_config",
  "apollo_metrics",
@@ -2040,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "anyhow",
  "apollo_compilation_utils",
@@ -2090,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "blockifier_reexecution"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_compile_to_casm",
  "apollo_compile_to_casm_types",
@@ -2118,7 +2118,7 @@ dependencies = [
 [[package]]
 name = "blockifier_test_utils"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-starknet-classes",
@@ -6614,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "mempool_test_utils"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_infra_utils",
  "assert_matches",
@@ -7209,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "papyrus_base_layer"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "alloy",
  "apollo_config",
@@ -7231,7 +7231,7 @@ dependencies = [
 [[package]]
 name = "papyrus_common"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "cairo-lang-starknet-classes",
  "indexmap 2.11.1",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=c07147e3233e6743964ca5280687728bb8a1e6b8#c07147e3233e6743964ca5280687728bb8a1e6b8"
 dependencies = [
  "apollo_infra_utils",
  "apollo_sizeof",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 [[package]]
 name = "apollo_class_manager_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_compile_to_casm_types",
  "apollo_infra",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "apollo_compilation_utils"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-sierra",
@@ -823,7 +823,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_casm"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_compile_to_casm_types",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_casm_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_infra",
  "apollo_metrics",
@@ -861,7 +861,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_compile_to_native_types",
@@ -874,7 +874,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_config",
  "serde",
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "apollo_config"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_infra_utils",
  "clap",
@@ -902,7 +902,7 @@ dependencies = [
 [[package]]
 name = "apollo_gateway"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_class_manager_types",
  "apollo_config",
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "apollo_gateway_config"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_config",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "apollo_gateway_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_infra",
  "apollo_network_types",
@@ -975,7 +975,7 @@ dependencies = [
 [[package]]
 name = "apollo_infra"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_config",
  "apollo_infra_utils",
@@ -998,7 +998,7 @@ dependencies = [
 [[package]]
 name = "apollo_infra_utils"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_proc_macros",
  "assert-json-diff",
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "apollo_l1_endpoint_monitor_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_infra",
  "apollo_metrics",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "apollo_mempool_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_infra",
  "apollo_metrics",
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "apollo_metrics"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "indexmap 2.11.1",
  "metrics",
@@ -1063,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "apollo_network_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "lazy_static",
  "libp2p",
@@ -1073,7 +1073,7 @@ dependencies = [
 [[package]]
 name = "apollo_proc_macros"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "apollo_rpc"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "anyhow",
  "apollo_class_manager_types",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "apollo_rpc_execution"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "anyhow",
  "apollo_class_manager_types",
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "apollo_sierra_compilation_config"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_config",
  "serde",
@@ -1153,7 +1153,7 @@ dependencies = [
 [[package]]
 name = "apollo_sizeof"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_sizeof_macros",
  "starknet-types-core",
@@ -1162,7 +1162,7 @@ dependencies = [
 [[package]]
 name = "apollo_sizeof_macros"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1172,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "apollo_starknet_client"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_config",
  "async-trait",
@@ -1198,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "apollo_state_sync_types"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_infra",
  "apollo_metrics",
@@ -1218,7 +1218,7 @@ dependencies = [
 [[package]]
 name = "apollo_storage"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_config",
  "apollo_metrics",
@@ -2040,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "anyhow",
  "apollo_compilation_utils",
@@ -2090,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "blockifier_reexecution"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_compile_to_casm",
  "apollo_compile_to_casm_types",
@@ -2118,7 +2118,7 @@ dependencies = [
 [[package]]
 name = "blockifier_test_utils"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-starknet-classes",
@@ -2875,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.9.0-rc.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=3299da5446b74b3d4e4682de7df08629ee6e0429#3299da5446b74b3d4e4682de7df08629ee6e0429"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=9e042d19409c822291bf351beaddd00a69d5f2b1#9e042d19409c822291bf351beaddd00a69d5f2b1"
 dependencies = [
  "aquamarine",
  "ark-ec 0.5.0",
@@ -2896,6 +2896,7 @@ dependencies = [
  "educe 0.5.11",
  "itertools 0.14.0",
  "keccak",
+ "lambdaworks-math",
  "lazy_static",
  "libc",
  "libloading",
@@ -6151,6 +6152,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rand 0.8.5",
+ "rayon",
  "serde",
  "serde_json",
 ]
@@ -6612,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "mempool_test_utils"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_infra_utils",
  "assert_matches",
@@ -7207,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "papyrus_base_layer"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "alloy",
  "apollo_config",
@@ -7229,7 +7231,7 @@ dependencies = [
 [[package]]
 name = "papyrus_common"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "cairo-lang-starknet-classes",
  "indexmap 2.11.1",
@@ -9021,7 +9023,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "sierra-emu"
 version = "0.9.0-rc.0"
-source = "git+https://github.com/lambdaclass/cairo_native?rev=3299da5446b74b3d4e4682de7df08629ee6e0429#3299da5446b74b3d4e4682de7df08629ee6e0429"
+source = "git+https://github.com/lambdaclass/cairo_native?rev=9e042d19409c822291bf351beaddd00a69d5f2b1#9e042d19409c822291bf351beaddd00a69d5f2b1"
 dependencies = [
  "cairo-lang-compiler",
  "cairo-lang-filesystem",
@@ -9306,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.16.0-rc.2"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b#52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=7cd5b16de61f8ad34581e7cb6ef673e048fe9597#7cd5b16de61f8ad34581e7cb6ef673e048fe9597"
 dependencies = [
  "apollo_infra_utils",
  "apollo_sizeof",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ cairo-lang-compiler = "~2.15.0"
 cairo-lang-sierra = "~2.15.0"
 
 # Sequencer Dependencies
-starknet_api = { git = "https://github.com/lambdaclass/sequencer.git", rev = "7cd5b16de61f8ad34581e7cb6ef673e048fe9597" } # update_native
-blockifier = { git = "https://github.com/lambdaclass/sequencer.git", rev = "7cd5b16de61f8ad34581e7cb6ef673e048fe9597", features = [ "cairo_native", ] } # update_native
-apollo_gateway = { git = "https://github.com/lambdaclass/sequencer.git", rev = "7cd5b16de61f8ad34581e7cb6ef673e048fe9597" } # update_native
-blockifier_reexecution = { git = "https://github.com/lambdaclass/sequencer.git", rev = "7cd5b16de61f8ad34581e7cb6ef673e048fe9597" } # update_native
+starknet_api = { git = "https://github.com/lambdaclass/sequencer.git", rev = "c07147e3233e6743964ca5280687728bb8a1e6b8" } # update_native
+blockifier = { git = "https://github.com/lambdaclass/sequencer.git", rev = "c07147e3233e6743964ca5280687728bb8a1e6b8", features = [ "cairo_native", ] } # update_native
+apollo_gateway = { git = "https://github.com/lambdaclass/sequencer.git", rev = "c07147e3233e6743964ca5280687728bb8a1e6b8" } # update_native
+blockifier_reexecution = { git = "https://github.com/lambdaclass/sequencer.git", rev = "c07147e3233e6743964ca5280687728bb8a1e6b8" } # update_native

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "1.0.135"
 serde_with = "3.12.0"
 serde = "1.0.219"
 fs2 = "0.4.3"
-cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "3299da5446b74b3d4e4682de7df08629ee6e0429" }
+cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "9e042d19409c822291bf351beaddd00a69d5f2b1" }
 cairo-vm = "3.0.0"
 anyhow = "1.0"
 
@@ -25,7 +25,7 @@ cairo-lang-compiler = "~2.15.0"
 cairo-lang-sierra = "~2.15.0"
 
 # Sequencer Dependencies
-starknet_api = { git = "https://github.com/lambdaclass/sequencer.git", rev = "52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b" } # main-v0.14.1
-blockifier = { git = "https://github.com/lambdaclass/sequencer.git", rev = "52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b", features = [ "cairo_native", ] } # main-v0.14.1
-apollo_gateway = { git = "https://github.com/lambdaclass/sequencer.git", rev = "52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b" } # main-v0.14.1
-blockifier_reexecution = { git = "https://github.com/lambdaclass/sequencer.git", rev = "52ca5be21eecbfe84cd5fa6f1cb9f4982198ab5b" } # main-v0.14.1
+starknet_api = { git = "https://github.com/lambdaclass/sequencer.git", rev = "7cd5b16de61f8ad34581e7cb6ef673e048fe9597" } # update_native
+blockifier = { git = "https://github.com/lambdaclass/sequencer.git", rev = "7cd5b16de61f8ad34581e7cb6ef673e048fe9597", features = [ "cairo_native", ] } # update_native
+apollo_gateway = { git = "https://github.com/lambdaclass/sequencer.git", rev = "7cd5b16de61f8ad34581e7cb6ef673e048fe9597" } # update_native
+blockifier_reexecution = { git = "https://github.com/lambdaclass/sequencer.git", rev = "7cd5b16de61f8ad34581e7cb6ef673e048fe9597" } # update_native


### PR DESCRIPTION
Bump Native to https://github.com/lambdaclass/cairo_native/commit/9e042d19409c822291bf351beaddd00a69d5f2b1

Depends on https://github.com/lambdaclass/sequencer/pull/85