### PR TITLE
Filter `cairo_native` entry when comparing state dumps

### DIFF
--- a/scripts/delta_state_dumps.sh
+++ b/scripts/delta_state_dumps.sh
@@ -30,8 +30,8 @@ for block in state_dumps/vm/*/; do
     fi
 
     if cmp -s \
-      <(sed '/"revert_error": /d' "$native_tx") \
-      <(sed '/"revert_error": /d' "$vm_tx")
+      <(sed '/"revert_error": /d; /cairo_native/d' "$native_tx") \
+      <(sed '/"revert_error": /d; /cairo_native/d' "$vm_tx")
     then
       continue
     fi


### PR DESCRIPTION
State dumps now include a `"cairo_native": <bool>` entry where its value is `true` if the related transaction was executed with Cairo Native and `false` otherwise. This PR filters that entry to avoid false positives when looking for state diffs.