### PR TITLE
Add `show_tx_diff.sh` script for viewing single transaction state diffs

### DIFF
--- a/scripts/show_tx_diff.sh
+++ b/scripts/show_tx_diff.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -e
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <block_number> <tx_hash>
+
+Display state diffs for a single transaction between Native and VM execution.
+
+Arguments:
+  block_number  The block number
+  tx_hash       The transaction hash
+
+Example:
+  $(basename "$0") 123456 0x1234abcd...
+EOF
+  exit 1
+}
+
+if [ $# -ne 2 ]; then
+  usage
+fi
+
+block_number="$1"
+tx_hash="$2"
+
+native_tx="state_dumps/native/block${block_number}/${tx_hash}.json"
+vm_tx="state_dumps/vm/block${block_number}/${tx_hash}.json"
+
+native_exists=false
+vm_exists=false
+
+[ -f "$native_tx" ] && native_exists=true
+[ -f "$vm_tx" ] && vm_exists=true
+
+if [ "$native_exists" = true ] && [ "$vm_exists" = true ]; then
+  delta "$native_tx" "$vm_tx" --side-by-side --paging always --wrap-max-lines unlimited
+elif [ "$native_exists" = false ] && [ "$vm_exists" = false ]; then
+  echo "no state diffs found in ${tx_hash} from block ${block_number}"
+elif [ "$native_exists" = false ]; then
+  echo "native does not have state diffs stored for ${tx_hash} from block ${block_number}"
+else
+  echo "vm does not have state diffs stored for ${tx_hash} from block ${block_number}"
+fi


### PR DESCRIPTION
Adds a script to display state diffs between Native and VM execution for a specific transaction, using the same delta flags as `delta_state_dumps.sh`.

**Example usage:**

After running replay in block 3565561, run:

```sh
./scripts/show_tx_diff.sh 3565561 0x654e363a0e5c9fe69eaa92a758cf82a798ebc5027472f16f063ea74e5f92e5b
```

If a state diff was found in that transaction, this command should output something like this:

```plain
state_dumps/native/block3552906/0x7405b6612d7decd832c3db0aa9adbc3be3f42c06f78a78d177cb6ca1fb4ae9b.json ⟶   state_dumps/vm/block3552906/0x7405b6612d7decd832c3db0aa9adbc3be3f42c06f78a78d177cb6ca1fb4ae9b.json
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

──────┐
1969: │
──────┘
│1969│        "0x344c86d9d9a189cf1b616c8d3bd550bdfd3f099f4076f7e680↴│1969│        "0x344c86d9d9a189cf1b616c8d3bd550bdfd3f099f4076f7e680↴
│    │                                              …a14d4d8981124",│    │                                              …a14d4d8981124",
│1970│        "0x145770"                                            │1970│        "0x145770"
│1971│      ],                                                      │1971│      ],
│1972│      [                                                       │    │
│1973│        "0x34b4fcacb3b119b3279952788fec4f775066668e8045ba1477↴│    │
│    │                                              …3863afab3cf34",│    │
│1974│        "0x7957"                                              │    │
│1975│      ],                                                      │    │
│1976│      [                                                       │1972│      [
│1977│        "0x35c5a3c4c37030c0e24d746fcfc4bcb11943ae0d7b177a4ab8↴│1973│        "0x35c5a3c4c37030c0e24d746fcfc4bcb11943ae0d7b177a4ab8↴
│    │                                              …a2c62f57b94cc",│    │                                              …a2c62f57b94cc",
│1978│        "0x67219"                                             │1974│        "0x67219"

```