### PR TITLE
Remove stale lock files before spawning workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 [[package]]
 name = "apollo_class_manager_types"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_compile_to_casm_types",
  "apollo_infra",
@@ -127,7 +127,7 @@ dependencies = [
 [[package]]
 name = "apollo_compilation_utils"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-sierra",
@@ -145,7 +145,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_casm"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_compile_to_casm_types",
@@ -166,7 +166,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_casm_types"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_infra",
  "apollo_metrics",
@@ -181,7 +181,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_compile_to_native_types",
@@ -194,7 +194,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native_types"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_config",
  "serde",
@@ -204,7 +204,7 @@ dependencies = [
 [[package]]
 name = "apollo_config"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_infra_utils",
  "clap",
@@ -222,7 +222,7 @@ dependencies = [
 [[package]]
 name = "apollo_infra"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_config",
  "apollo_infra_utils",
@@ -252,7 +252,7 @@ dependencies = [
 [[package]]
 name = "apollo_infra_utils"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_proc_macros",
  "assert-json-diff",
@@ -274,7 +274,7 @@ dependencies = [
 [[package]]
 name = "apollo_metrics"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_time",
  "indexmap 2.11.1",
@@ -282,12 +282,13 @@ dependencies = [
  "num-traits",
  "paste",
  "regex",
+ "strum",
 ]
 
 [[package]]
 name = "apollo_proc_macros"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -298,7 +299,7 @@ dependencies = [
 [[package]]
 name = "apollo_rpc_execution"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "anyhow",
  "apollo_class_manager_types",
@@ -323,7 +324,7 @@ dependencies = [
 [[package]]
 name = "apollo_sierra_compilation_config"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_config",
  "serde",
@@ -333,7 +334,7 @@ dependencies = [
 [[package]]
 name = "apollo_sizeof"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_sizeof_macros",
  "starknet-types-core",
@@ -342,7 +343,7 @@ dependencies = [
 [[package]]
 name = "apollo_sizeof_macros"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -352,7 +353,7 @@ dependencies = [
 [[package]]
 name = "apollo_storage"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_config",
  "apollo_metrics",
@@ -363,6 +364,7 @@ dependencies = [
  "cairo-lang-casm",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
+ "http",
  "http-body-util",
  "human_bytes",
  "indexmap 2.11.1",
@@ -389,7 +391,7 @@ dependencies = [
 [[package]]
 name = "apollo_time"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "chrono",
 ]
@@ -851,7 +853,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "anyhow",
  "apollo_compilation_utils",
@@ -901,7 +903,7 @@ dependencies = [
 [[package]]
 name = "blockifier_reexecution"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_compile_to_casm",
  "apollo_compile_to_casm_types",
@@ -930,21 +932,18 @@ dependencies = [
 [[package]]
 name = "blockifier_test_utils"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-starknet-classes",
- "expect-test",
- "pretty_assertions",
- "rstest",
+ "digest",
  "serde_json",
+ "sha2",
  "starknet-types-core",
  "starknet_api",
  "strum",
  "tempfile",
- "tokio",
  "tracing",
- "tracing-test",
 ]
 
 [[package]]
@@ -1784,7 +1783,7 @@ version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -2898,12 +2897,6 @@ dependencies = [
  "spin",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -4170,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "papyrus_common"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "cairo-lang-starknet-classes",
  "indexmap 2.11.1",
@@ -5610,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.18.0-dev.0"
-source = "git+https://github.com/lambdaclass/sequencer.git?rev=995d850b31ff942058e400b69e853a437bbbedde#995d850b31ff942058e400b69e853a437bbbedde"
+source = "git+https://github.com/lambdaclass/sequencer.git?rev=594e2e2a1d5258c4310b77796f42b39ef567523f#594e2e2a1d5258c4310b77796f42b39ef567523f"
 dependencies = [
  "apollo_infra_utils",
  "apollo_sizeof",
@@ -5702,23 +5695,22 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.106",
 ]
 
@@ -6258,27 +6250,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
-]
-
-[[package]]
-name = "tracing-test"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
-dependencies = [
- "tracing-core",
- "tracing-subscriber",
- "tracing-test-macro",
-]
-
-[[package]]
-name = "tracing-test-macro"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
-dependencies = [
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,8 +1660,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "182965d2ccbc05674f798b30097854ecf015eed695194a3a5fe9b682c4163b9d"
+source = "git+https://github.com/avivg-starkware/cairo-vm?rev=2ad6d5fba6df67da62309bb64d1482a47ad54132#2ad6d5fba6df67da62309bb64d1482a47ad54132"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ cairo-lang-compiler = "~2.16.0"
 cairo-lang-sierra = "~2.16.0"
 
 # Sequencer Dependencies
-starknet_api = { git = "https://github.com/lambdaclass/sequencer.git", rev = "995d850b31ff942058e400b69e853a437bbbedde" } # update_native
-blockifier = { git = "https://github.com/lambdaclass/sequencer.git", rev = "995d850b31ff942058e400b69e853a437bbbedde", features = [ "cairo_native", ] } # update_native
-blockifier_reexecution = { git = "https://github.com/lambdaclass/sequencer.git", rev = "995d850b31ff942058e400b69e853a437bbbedde" } # update_native
+starknet_api = { git = "https://github.com/lambdaclass/sequencer.git", rev = "594e2e2a1d5258c4310b77796f42b39ef567523f" } # update_native
+blockifier = { git = "https://github.com/lambdaclass/sequencer.git", rev = "594e2e2a1d5258c4310b77796f42b39ef567523f", features = [ "cairo_native", ] } # update_native
+blockifier_reexecution = { git = "https://github.com/lambdaclass/sequencer.git", rev = "594e2e2a1d5258c4310b77796f42b39ef567523f" } # update_native

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde_with = "3.12.0"
 serde = "1.0.219"
 fs2 = "0.4.3"
 cairo-native = { git = "https://github.com/lambdaclass/cairo_native", rev = "b3fea26c8a3f3a48d0f1b473d7439435c6389083" }
-cairo-vm = "3.0.1"
+cairo-vm = "3.1.0"
 anyhow = "1.0"
 
 # Cairo Dependencies
@@ -28,3 +28,6 @@ cairo-lang-sierra = "~2.16.0"
 starknet_api = { git = "https://github.com/lambdaclass/sequencer.git", rev = "594e2e2a1d5258c4310b77796f42b39ef567523f" } # update_native
 blockifier = { git = "https://github.com/lambdaclass/sequencer.git", rev = "594e2e2a1d5258c4310b77796f42b39ef567523f", features = [ "cairo_native", ] } # update_native
 blockifier_reexecution = { git = "https://github.com/lambdaclass/sequencer.git", rev = "594e2e2a1d5258c4310b77796f42b39ef567523f" } # update_native
+
+[patch.crates-io]
+cairo-vm = { git = "https://github.com/avivg-starkware/cairo-vm", rev = "2ad6d5fba6df67da62309bb64d1482a47ad54132" }

--- a/scripts/mux.sh
+++ b/scripts/mux.sh
@@ -78,6 +78,15 @@ spawn() {
 	fi
 }
 
+clean_stale_locks() {
+	local count
+	count=$(find cache/contract_class/ -name '*.lock' 2>/dev/null | wc -l)
+	if [ "$count" -gt 0 ]; then
+		echo "Removing $count stale lock file(s) from cache/contract_class/"
+		find cache/contract_class/ -name '*.lock' -delete
+	fi
+}
+
 build_native() {
 	echo "Building replay for Cairo Native"
 	cargo build --quiet --release --features structured_logging,state_dump
@@ -177,6 +186,8 @@ range() {
 		build_vm
 	fi
 
+	clean_stale_locks
+
 	# Spawn executors.
 	for ((i = START_BLOCK ; i <= end_block ; i += step_size )); do
 		current_start_block="$i"
@@ -221,6 +232,8 @@ block() {
 	if [ "$SKIP" != "vm" ]; then
 		build_vm
 	fi
+
+	clean_stale_locks
 
 	for block in "${@:2}"; do
 		# Spawn VM executor if required.


### PR DESCRIPTION
Stale `.lock` files in `cache/contract_class/` cause workers to hang indefinitely waiting on a lock that will never be released. This adds a cleanup step before spawning workers in both `range` and `block` commands.